### PR TITLE
Add support for graph export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dependencies = [
 	"nbformat==5.10.4",
 	"Jinja2==3.1.6",
 	"pandas==2.3.3",
+	"plotly==6.5.1",
+	"matplotlib==3.10.8",
 ]
 
 

--- a/src/overity/api/__init__.py
+++ b/src/overity/api/__init__.py
@@ -22,6 +22,9 @@ from overity.errors import UnknownMethodError
 
 from overity.backend.flow.ctx import FlowCtx, RunMode
 
+from matplotlib.figure import Figure as MplFigure
+from plotly.graph_objects import Figure as PlotlyFigure
+
 
 # Initialize global flow object
 _CTX = FlowCtx.default()
@@ -103,6 +106,14 @@ def in_preview_stage():
 
 def epoch_metric_df(key: str):
     return flow.epoch_metric_df(_CTX, key)
+
+
+def graph_save_mpl(identifier: str, fig: MplFigure):
+    return flow.graph_save_mpl(_CTX, identifier, fig)
+
+
+def graph_save_plotly(identifier: str, fig: PlotlyFigure):
+    return flow.graph_save_plotly(_CTX, identifier, fig)
 
 
 ####################################################

--- a/src/overity/errors.py
+++ b/src/overity/errors.py
@@ -178,3 +178,8 @@ class InvalidEpochValue(Exception):
             f"Invalid epoch value: {epoch}. Epoch must be a non-negative integer."
         )
         self.epoch = epoch
+
+
+class DuplicateFigureError(Exception):
+    def __init__(self, fig_identifier: str):
+        super().__init__(f"Duplicate figure identifier: {fig_identifier}")

--- a/src/overity/model/report/__init__.py
+++ b/src/overity/model/report/__init__.py
@@ -24,7 +24,11 @@ from overity.model.report.metrics import (
     Metric,
 )
 
-import pandas as pd
+from typing import TYPE_CHECKING
+from pandas import DataFrame
+
+if TYPE_CHECKING:
+    from plotly.graph_objects import Figure
 
 
 class MethodExecutionStatus(Enum):
@@ -86,6 +90,7 @@ class MethodReport:
     outputs: any | None = None
     metrics: dict[str, Metric] | None = None
     epoch_metrics: dict[int, dict[str, Metric]] | None = None
+    graphs: dict[str, Figure] | None = None
 
     @classmethod
     def default(
@@ -112,6 +117,7 @@ class MethodReport:
             outputs=None,
             metrics={},
             epoch_metrics={},
+            graphs={},
         )
 
     def log_add(self, tstamp: dt, severity: str, source: str, message: str):
@@ -124,7 +130,7 @@ class MethodReport:
             )
         )
 
-    def epoch_metric_df(self, key: str) -> pd.DataFrame | None:
+    def epoch_metric_df(self, key: str) -> DataFrame | None:
         """Get a pandas dataframe containing values for a specific item value
 
         Args:
@@ -138,6 +144,6 @@ class MethodReport:
         rows = [{"epoch": k, **asdict(v[key])} for k, v in self.epoch_metrics.items()]
 
         if rows:
-            return pd.DataFrame(rows).set_index("epoch")
+            return DataFrame(rows).set_index("epoch")
         else:  # Empty metrics
             return None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,43 +17,49 @@ class TestEpochMetrics:
     def test_epoch_metrics_returns_metric_saver(self):
         """Test that epoch_metrics returns a MetricSaver instance."""
         # Mock the flow.epoch_metrics function
-        with patch('overity.api.flow.epoch_metrics') as mock_flow_epoch_metrics:
+        with patch("overity.api.flow.epoch_metrics") as mock_flow_epoch_metrics:
             # Create a mock MetricSaver instance
             mock_metric_saver = Mock(spec=MetricSaver)
             mock_flow_epoch_metrics.return_value = mock_metric_saver
-            
+
             # Call the function
             result = overity.api.epoch_metrics(1)
-            
+
             # Verify the result
             assert result == mock_metric_saver
             mock_flow_epoch_metrics.assert_called_once()
 
     def test_epoch_metrics_calls_flow_with_correct_args(self):
         """Test that epoch_metrics calls flow.epoch_metrics with correct arguments."""
-        with patch('overity.api.flow.epoch_metrics') as mock_flow_epoch_metrics:
+        with patch("overity.api.flow.epoch_metrics") as mock_flow_epoch_metrics:
             mock_metric_saver = Mock(spec=MetricSaver)
             mock_flow_epoch_metrics.return_value = mock_metric_saver
-            
+
             # Call with different epoch numbers
             overity.api.epoch_metrics(5)
             overity.api.epoch_metrics(10)
             overity.api.epoch_metrics(0)
-            
+
             # Verify calls
             assert mock_flow_epoch_metrics.call_count == 3
-            mock_flow_epoch_metrics.assert_any_call(overity.api._CTX, 5)
-            mock_flow_epoch_metrics.assert_any_call(overity.api._CTX, 10)
-            mock_flow_epoch_metrics.assert_any_call(overity.api._CTX, 0)
+            mock_flow_epoch_metrics.assert_any_call(
+                overity.api._CTX, 5, display_output=True
+            )
+            mock_flow_epoch_metrics.assert_any_call(
+                overity.api._CTX, 10, display_output=True
+            )
+            mock_flow_epoch_metrics.assert_any_call(
+                overity.api._CTX, 0, display_output=True
+            )
 
     def test_epoch_metrics_with_context_manager_usage(self):
         """Test epoch_metrics used as a context manager."""
-        with patch('overity.api.flow.epoch_metrics') as mock_flow_epoch_metrics:
+        with patch("overity.api.flow.epoch_metrics") as mock_flow_epoch_metrics:
             # Create a real MetricSaver instance for testing context manager
             mock_output_dict = {}
             metric_saver = MetricSaver("Epoch 1 metrics", mock_output_dict)
             mock_flow_epoch_metrics.return_value = metric_saver
-            
+
             # Use as context manager
             with overity.api.epoch_metrics(1) as metrics:
                 # Verify we can call metric methods
@@ -61,7 +67,7 @@ class TestEpochMetrics:
                 metrics.percentage("validation_accuracy", 0.92)
                 metrics.scale_lin("loss", 0.05, 0.0, 1.0)
                 metrics.range_lin("epoch", 1, 1, 100)
-            
+
             # Verify metrics were recorded
             assert "accuracy" in mock_output_dict
             assert "validation_accuracy" in mock_output_dict
@@ -70,122 +76,130 @@ class TestEpochMetrics:
 
     def test_epoch_metrics_multiple_epochs(self):
         """Test using epoch_metrics with multiple different epochs."""
-        with patch('overity.api.flow.epoch_metrics') as mock_flow_epoch_metrics:
+        with patch("overity.api.flow.epoch_metrics") as mock_flow_epoch_metrics:
             # Create different output dicts for different epochs
             epoch1_dict = {}
             epoch5_dict = {}
             epoch10_dict = {}
-            
+
             epoch1_saver = MetricSaver("Epoch 1 metrics", epoch1_dict)
             epoch5_saver = MetricSaver("Epoch 5 metrics", epoch5_dict)
             epoch10_saver = MetricSaver("Epoch 10 metrics", epoch10_dict)
-            
-            mock_flow_epoch_metrics.side_effect = [epoch1_saver, epoch5_saver, epoch10_saver]
-            
+
+            mock_flow_epoch_metrics.side_effect = [
+                epoch1_saver,
+                epoch5_saver,
+                epoch10_saver,
+            ]
+
             # Use different epochs
             with overity.api.epoch_metrics(1) as metrics1:
                 metrics1.simple("loss", 0.8)
                 metrics1.percentage("accuracy", 0.65)
-            
+
             with overity.api.epoch_metrics(5) as metrics5:
                 metrics5.simple("loss", 0.3)
                 metrics5.percentage("accuracy", 0.85)
-            
+
             with overity.api.epoch_metrics(10) as metrics10:
                 metrics10.simple("loss", 0.1)
                 metrics10.percentage("accuracy", 0.95)
-            
+
             # Verify each epoch has its own metrics
             assert epoch1_dict["loss"].value == 0.8
             assert epoch1_dict["accuracy"].value == 0.65
-            
+
             assert epoch5_dict["loss"].value == 0.3
             assert epoch5_dict["accuracy"].value == 0.85
-            
+
             assert epoch10_dict["loss"].value == 0.1
             assert epoch10_dict["accuracy"].value == 0.95
 
     def test_epoch_metrics_negative_epoch(self):
         """Test epoch_metrics with negative epoch number raises InvalidEpochValue."""
         # Mock the flow function to bypass API initialization check
-        with patch('overity.api.flow.epoch_metrics') as mock_flow_epoch_metrics:
+        with patch("overity.api.flow.epoch_metrics") as mock_flow_epoch_metrics:
             # Configure the flow function to raise InvalidEpochValue for negative epochs
-            def side_effect(ctx, epoch):
+            def side_effect(ctx, epoch, display_output=True):
                 if epoch < 0:
                     raise InvalidEpochValue(epoch)
                 return Mock()  # Return a mock MetricSaver for valid epochs
-            
+
             mock_flow_epoch_metrics.side_effect = side_effect
-            
+
             # Should raise InvalidEpochValue for negative epoch numbers
             with pytest.raises(InvalidEpochValue) as exc_info:
                 overity.api.epoch_metrics(-1)
-            
+
             # Verify the exception contains the correct epoch value
             assert exc_info.value.epoch == -1
-            
+
             # Verify that the flow function was called
-            mock_flow_epoch_metrics.assert_called_once_with(overity.api._CTX, -1)
+            mock_flow_epoch_metrics.assert_called_once_with(
+                overity.api._CTX, -1, display_output=True
+            )
 
     def test_epoch_metrics_large_epoch_number(self):
         """Test epoch_metrics with large epoch number."""
-        with patch('overity.api.flow.epoch_metrics') as mock_flow_epoch_metrics:
+        with patch("overity.api.flow.epoch_metrics") as mock_flow_epoch_metrics:
             mock_metric_saver = Mock(spec=MetricSaver)
             mock_flow_epoch_metrics.return_value = mock_metric_saver
-            
+
             # Test with large epoch number
             large_epoch = 1000000
             result = overity.api.epoch_metrics(large_epoch)
-            
+
             assert result == mock_metric_saver
-            mock_flow_epoch_metrics.assert_called_once_with(overity.api._CTX, large_epoch)
+            mock_flow_epoch_metrics.assert_called_once_with(
+                overity.api._CTX, large_epoch, display_output=True
+            )
 
     def test_epoch_metrics_zero_epoch(self):
         """Test epoch_metrics with epoch 0."""
-        with patch('overity.api.flow.epoch_metrics') as mock_flow_epoch_metrics:
+        with patch("overity.api.flow.epoch_metrics") as mock_flow_epoch_metrics:
             mock_output_dict = {}
             metric_saver = MetricSaver("Epoch 0 metrics", mock_output_dict)
             mock_flow_epoch_metrics.return_value = metric_saver
-            
+
             # Use epoch 0 (common in ML frameworks)
             with overity.api.epoch_metrics(0) as metrics:
                 metrics.simple("initial_loss", 2.5)
                 metrics.percentage("initial_accuracy", 0.10)
-            
+
             # Verify metrics were recorded
             assert mock_output_dict["initial_loss"].value == 2.5
             assert mock_output_dict["initial_accuracy"].value == 0.10
 
-    @patch('overity.api._CTX')
+    @patch("overity.api._CTX")
     def test_epoch_metrics_with_uninitialized_api(self, mock_ctx):
         """Test epoch_metrics behavior when API is not initialized."""
         # Mock context to simulate uninitialized API
         mock_ctx.init_ok = False
-        
-        with patch('overity.api.flow.epoch_metrics') as mock_flow_epoch_metrics:
+
+        with patch("overity.api.flow.epoch_metrics") as mock_flow_epoch_metrics:
             # Configure the flow function to raise UninitAPIError
             mock_flow_epoch_metrics.side_effect = UninitAPIError()
-            
+
             # Should raise UninitAPIError when API not initialized
             with pytest.raises(UninitAPIError):
                 overity.api.epoch_metrics(1)
 
     def test_epoch_metrics_same_epoch_multiple_calls(self):
         """Test multiple calls to epoch_metrics with the same epoch."""
-        with patch('overity.api.flow.epoch_metrics') as mock_flow_epoch_metrics:
+        with patch("overity.api.flow.epoch_metrics") as mock_flow_epoch_metrics:
             # Same output dict for same epoch
             shared_dict = {}
             metric_saver = MetricSaver("Epoch 1 metrics", shared_dict)
             mock_flow_epoch_metrics.return_value = metric_saver
-            
+
             # Multiple calls with same epoch
             with overity.api.epoch_metrics(1) as metrics1:
                 metrics1.simple("accuracy", 0.80)
-            
+
             with overity.api.epoch_metrics(1) as metrics2:
                 metrics2.simple("loss", 0.4)
                 metrics2.percentage("validation_accuracy", 0.75)
-            
+
             # Verify both sets of metrics are in the same dictionary
             assert len(shared_dict) == 3
             assert shared_dict["accuracy"].value == 0.80
@@ -194,32 +208,37 @@ class TestEpochMetrics:
 
     def test_epoch_metrics_metric_types(self):
         """Test all available metric types in epoch_metrics."""
-        with patch('overity.api.flow.epoch_metrics') as mock_flow_epoch_metrics:
+        with patch("overity.api.flow.epoch_metrics") as mock_flow_epoch_metrics:
             mock_output_dict = {}
             metric_saver = MetricSaver("Epoch 1 metrics", mock_output_dict)
             mock_flow_epoch_metrics.return_value = metric_saver
-            
+
             # Test all metric types
             with overity.api.epoch_metrics(1) as metrics:
                 metrics.simple("accuracy", 0.95)
                 metrics.percentage("accuracy_pct", 0.95)
                 metrics.scale_lin("loss_scaled", 0.3, 0.0, 1.0)
                 metrics.range_lin("batch_size", 32, 8, 128)
-            
+
             # Verify correct metric types were created
-            from overity.model.report.metrics import SimpleValue, PercentageValue, LinScaleValue, LinRangeValue
-            
+            from overity.model.report.metrics import (
+                SimpleValue,
+                PercentageValue,
+                LinScaleValue,
+                LinRangeValue,
+            )
+
             assert isinstance(mock_output_dict["accuracy"], SimpleValue)
             assert mock_output_dict["accuracy"].value == 0.95
-            
+
             assert isinstance(mock_output_dict["accuracy_pct"], PercentageValue)
             assert mock_output_dict["accuracy_pct"].value == 0.95
-            
+
             assert isinstance(mock_output_dict["loss_scaled"], LinScaleValue)
             assert mock_output_dict["loss_scaled"].value == 0.3
             assert mock_output_dict["loss_scaled"].low == 0.0
             assert mock_output_dict["loss_scaled"].high == 1.0
-            
+
             assert isinstance(mock_output_dict["batch_size"], LinRangeValue)
             assert mock_output_dict["batch_size"].value == 32
             assert mock_output_dict["batch_size"].low == 8
@@ -229,20 +248,20 @@ class TestEpochMetrics:
         """Test backend flow.epoch_metrics directly with negative epoch."""
         from overity.backend.flow import epoch_metrics as backend_epoch_metrics
         from overity.backend.flow.ctx import FlowCtx
-        
+
         # Create a mock context with initialized report
         mock_ctx = Mock(spec=FlowCtx)
         mock_ctx.report = Mock()
         mock_ctx.report.epoch_metrics = {}
         mock_ctx.init_ok = True  # Bypass API guard
-        
+
         # Should raise InvalidEpochValue for negative epoch
         with pytest.raises(InvalidEpochValue) as exc_info:
             backend_epoch_metrics(mock_ctx, -5)
-        
+
         # Verify the exception contains the correct epoch value
         assert exc_info.value.epoch == -5
-        
+
         # Verify that no metrics dictionary was created
         assert len(mock_ctx.report.epoch_metrics) == 0
 
@@ -250,23 +269,23 @@ class TestEpochMetrics:
         """Test backend flow.epoch_metrics with valid non-negative epochs."""
         from overity.backend.flow import epoch_metrics as backend_epoch_metrics
         from overity.backend.flow.ctx import FlowCtx
-        
+
         # Create a mock context with initialized report
         mock_ctx = Mock(spec=FlowCtx)
         mock_ctx.report = Mock()
         mock_ctx.report.epoch_metrics = {}
         mock_ctx.init_ok = True  # Bypass API guard
-        
+
         # Test with valid epochs (including zero)
         result_0 = backend_epoch_metrics(mock_ctx, 0)
         result_1 = backend_epoch_metrics(mock_ctx, 1)
         result_100 = backend_epoch_metrics(mock_ctx, 100)
-        
+
         # Verify that MetricSaver instances are returned
         assert isinstance(result_0, MetricSaver)
         assert isinstance(result_1, MetricSaver)
         assert isinstance(result_100, MetricSaver)
-        
+
         # Verify that metrics dictionaries were created
         assert 0 in mock_ctx.report.epoch_metrics
         assert 1 in mock_ctx.report.epoch_metrics

--- a/tests/test_model_report_epoch_metric_df.py
+++ b/tests/test_model_report_epoch_metric_df.py
@@ -8,10 +8,32 @@ from datetime import datetime as dt
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 
-from overity.model.report import MethodReport, MethodExecutionStage, MethodExecutionStatus
-from overity.model.report.metrics import SimpleValue, LinScaleValue, LinRangeValue, PercentageValue
+from overity.model.report import (
+    MethodReport,
+    MethodExecutionStage,
+    MethodExecutionStatus,
+)
+from overity.model.report.metrics import (
+    SimpleValue,
+    LinScaleValue,
+    LinRangeValue,
+    PercentageValue,
+)
 from overity.model.general_info.method import MethodInfo, MethodKind, MethodAuthor
 from overity.model.traceability import ArtifactGraph
+
+# Import plotly for graph testing
+try:
+    import plotly.graph_objects as go
+    from plotly.graph_objects import Figure
+
+    PLOTLY_AVAILABLE = True
+except ImportError:
+    PLOTLY_AVAILABLE = False
+
+    # Create a dummy Figure class for type hints
+    class Figure:
+        pass
 
 
 class TestMethodReportEpochMetricDf:
@@ -68,18 +90,19 @@ class TestMethodReportEpochMetricDf:
             metrics={},
             epoch_metrics=self.epoch_metrics,
             outputs=None,
+            graphs={} if PLOTLY_AVAILABLE else None,
         )
 
     def test_epoch_metric_df_simple_value(self):
         """Test epoch_metric_df with SimpleValue metrics."""
         # Test accuracy metric
         df = self.report.epoch_metric_df("accuracy")
-        
+
         # Verify DataFrame structure
         assert isinstance(df, pd.DataFrame)
         assert df.index.name == "epoch"
         assert list(df.columns) == ["value"]
-        
+
         # Verify data
         assert len(df) == 3
         assert df.loc[1, "value"] == 0.8
@@ -90,22 +113,22 @@ class TestMethodReportEpochMetricDf:
         """Test epoch_metric_df with LinScaleValue metrics."""
         # Test learning_rate metric
         df = self.report.epoch_metric_df("learning_rate")
-        
+
         # Verify DataFrame structure
         assert isinstance(df, pd.DataFrame)
         assert df.index.name == "epoch"
         assert list(df.columns) == ["low", "high", "value"]
-        
+
         # Verify data
         assert len(df) == 3
         assert df.loc[1, "low"] == 0.001
         assert df.loc[1, "high"] == 0.1
         assert df.loc[1, "value"] == 0.01
-        
+
         assert df.loc[2, "low"] == 0.001
         assert df.loc[2, "high"] == 0.1
         assert df.loc[2, "value"] == 0.009
-        
+
         assert df.loc[3, "low"] == 0.001
         assert df.loc[3, "high"] == 0.1
         assert df.loc[3, "value"] == 0.008
@@ -114,12 +137,12 @@ class TestMethodReportEpochMetricDf:
         """Test epoch_metric_df with PercentageValue metrics."""
         # Test progress metric
         df = self.report.epoch_metric_df("progress")
-        
+
         # Verify DataFrame structure
         assert isinstance(df, pd.DataFrame)
         assert df.index.name == "epoch"
         assert list(df.columns) == ["value"]
-        
+
         # Verify data
         assert len(df) == 3
         assert df.loc[1, "value"] == 0.1
@@ -130,12 +153,12 @@ class TestMethodReportEpochMetricDf:
         """Test epoch_metric_df with loss metrics."""
         # Test loss metric
         df = self.report.epoch_metric_df("loss")
-        
+
         # Verify DataFrame structure
         assert isinstance(df, pd.DataFrame)
         assert df.index.name == "epoch"
         assert list(df.columns) == ["value"]
-        
+
         # Verify data
         assert len(df) == 3
         assert df.loc[1, "value"] == 0.2
@@ -161,9 +184,9 @@ class TestMethodReportEpochMetricDf:
             epoch_metrics={},
             outputs=None,
         )
-        
+
         df = report.epoch_metric_df("accuracy")
-        
+
         # Verify empty DataFrame
         assert df is None
 
@@ -186,7 +209,7 @@ class TestMethodReportEpochMetricDf:
             epoch_metrics=None,
             outputs=None,
         )
-        
+
         # This should raise an error since epoch_metrics is None
         with pytest.raises((AttributeError, TypeError)):
             report.epoch_metric_df("accuracy")
@@ -206,7 +229,7 @@ class TestMethodReportEpochMetricDf:
                 "loss": SimpleValue(0.05),
             }
         }
-        
+
         report = MethodReport(
             uuid="test-uuid",
             program="test-program",
@@ -223,9 +246,9 @@ class TestMethodReportEpochMetricDf:
             epoch_metrics=single_epoch_metrics,
             outputs=None,
         )
-        
+
         df = report.epoch_metric_df("accuracy")
-        
+
         # Verify single row DataFrame
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 1
@@ -240,7 +263,7 @@ class TestMethodReportEpochMetricDf:
             5: {"accuracy": SimpleValue(0.85)},
             10: {"accuracy": SimpleValue(0.9)},
         }
-        
+
         report = MethodReport(
             uuid="test-uuid",
             program="test-program",
@@ -257,9 +280,9 @@ class TestMethodReportEpochMetricDf:
             epoch_metrics=non_sequential_metrics,
             outputs=None,
         )
-        
+
         df = report.epoch_metric_df("accuracy")
-        
+
         # Verify DataFrame with non-sequential indices
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 3
@@ -275,7 +298,7 @@ class TestMethodReportEpochMetricDf:
             1: {"accuracy": SimpleValue(0.8)},
             2: {"accuracy": LinScaleValue(low=0.0, high=1.0, value=0.85)},
         }
-        
+
         report = MethodReport(
             uuid="test-uuid",
             program="test-program",
@@ -292,11 +315,11 @@ class TestMethodReportEpochMetricDf:
             epoch_metrics=mixed_metrics,
             outputs=None,
         )
-        
+
         # This will create a DataFrame with mixed column structures
         # which may not be ideal but should not crash
         df = report.epoch_metric_df("accuracy")
-        
+
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 2
         # The exact structure depends on how pandas handles missing columns
@@ -310,7 +333,7 @@ class TestMethodReportEpochMetricDf:
             2000: {"accuracy": SimpleValue(0.96)},
             5000: {"accuracy": SimpleValue(0.97)},
         }
-        
+
         report = MethodReport(
             uuid="test-uuid",
             program="test-program",
@@ -327,9 +350,9 @@ class TestMethodReportEpochMetricDf:
             epoch_metrics=large_epoch_metrics,
             outputs=None,
         )
-        
+
         df = report.epoch_metric_df("accuracy")
-        
+
         # Verify DataFrame with large epoch numbers
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 3
@@ -346,7 +369,7 @@ class TestMethodReportEpochMetricDf:
             2: {"iterations": LinRangeValue(low=0, high=100, value=50)},
             3: {"iterations": LinRangeValue(low=0, high=100, value=75)},
         }
-        
+
         report = MethodReport(
             uuid="test-uuid",
             program="test-program",
@@ -363,24 +386,136 @@ class TestMethodReportEpochMetricDf:
             epoch_metrics=lin_range_metrics,
             outputs=None,
         )
-        
+
         df = report.epoch_metric_df("iterations")
-        
+
         # Verify DataFrame structure
         assert isinstance(df, pd.DataFrame)
         assert df.index.name == "epoch"
         assert list(df.columns) == ["low", "high", "value"]
-        
+
         # Verify data
         assert len(df) == 3
         assert df.loc[1, "low"] == 0
         assert df.loc[1, "high"] == 100
         assert df.loc[1, "value"] == 25
-        
+
         assert df.loc[2, "low"] == 0
         assert df.loc[2, "high"] == 100
         assert df.loc[2, "value"] == 50
-        
+
         assert df.loc[3, "low"] == 0
         assert df.loc[3, "high"] == 100
         assert df.loc[3, "value"] == 75
+
+    @pytest.mark.skipif(not PLOTLY_AVAILABLE, reason="plotly not available")
+    def test_method_report_with_graphs(self):
+        """Test that MethodReport can handle graphs field correctly."""
+        # Create sample plotly figures
+        fig1 = go.Figure()
+        fig1.add_trace(go.Scatter(x=[1, 2, 3], y=[4, 5, 6]))
+
+        fig2 = go.Figure()
+        fig2.add_trace(go.Bar(x=["A", "B", "C"], y=[10, 20, 30]))
+
+        # Create report with graphs
+        report_with_graphs = MethodReport(
+            uuid="test-graphs-uuid",
+            program="test-program",
+            date_started=dt(2023, 1, 1, 10, 0, 0),
+            date_ended=dt(2023, 1, 1, 11, 0, 0),
+            stage=MethodExecutionStage.Preview,
+            status=MethodExecutionStatus.ExecutionSuccess,
+            environment={},
+            context={},
+            method_info=self.method_info,
+            traceability_graph=ArtifactGraph.default(),
+            logs=[],
+            metrics={},
+            epoch_metrics={},
+            outputs=None,
+            graphs={"accuracy_plot": fig1, "loss_plot": fig2},
+        )
+
+        # Verify graphs are stored correctly
+        assert report_with_graphs.graphs is not None
+        assert len(report_with_graphs.graphs) == 2
+        assert "accuracy_plot" in report_with_graphs.graphs
+        assert "loss_plot" in report_with_graphs.graphs
+
+        # Verify the figures are correct
+        assert isinstance(report_with_graphs.graphs["accuracy_plot"], go.Figure)
+        assert isinstance(report_with_graphs.graphs["loss_plot"], go.Figure)
+
+        # Verify figure data
+        acc_fig = report_with_graphs.graphs["accuracy_plot"]
+        assert acc_fig.data[0].type == "scatter"
+        assert list(acc_fig.data[0].x) == [1, 2, 3]
+        assert list(acc_fig.data[0].y) == [4, 5, 6]
+
+        loss_fig = report_with_graphs.graphs["loss_plot"]
+        assert loss_fig.data[0].type == "bar"
+        assert list(loss_fig.data[0].x) == ["A", "B", "C"]
+        assert list(loss_fig.data[0].y) == [10, 20, 30]
+
+    def test_method_report_empty_graphs(self):
+        """Test that MethodReport can handle empty graphs dictionary."""
+        report_empty_graphs = MethodReport(
+            uuid="test-empty-graphs-uuid",
+            program="test-program",
+            date_started=dt(2023, 1, 1, 10, 0, 0),
+            date_ended=dt(2023, 1, 1, 11, 0, 0),
+            stage=MethodExecutionStage.Preview,
+            status=MethodExecutionStatus.ExecutionSuccess,
+            environment={},
+            context={},
+            method_info=self.method_info,
+            traceability_graph=ArtifactGraph.default(),
+            logs=[],
+            metrics={},
+            epoch_metrics={},
+            outputs=None,
+            graphs={},
+        )
+
+        # Verify empty graphs dictionary
+        assert report_empty_graphs.graphs is not None
+        assert len(report_empty_graphs.graphs) == 0
+
+    def test_method_report_none_graphs(self):
+        """Test that MethodReport can handle None graphs field."""
+        report_none_graphs = MethodReport(
+            uuid="test-none-graphs-uuid",
+            program="test-program",
+            date_started=dt(2023, 1, 1, 10, 0, 0),
+            date_ended=dt(2023, 1, 1, 11, 0, 0),
+            stage=MethodExecutionStage.Preview,
+            status=MethodExecutionStatus.ExecutionSuccess,
+            environment={},
+            context={},
+            method_info=self.method_info,
+            traceability_graph=ArtifactGraph.default(),
+            logs=[],
+            metrics={},
+            epoch_metrics={},
+            outputs=None,
+            graphs=None,
+        )
+
+        # Verify None graphs field
+        assert report_none_graphs.graphs is None
+
+    def test_method_report_default_graphs(self):
+        """Test that MethodReport default() method includes empty graphs."""
+        # Create a minimal report using the default() method
+        report_default = MethodReport.default(
+            uuid="test-default-uuid",
+            program="test-default-program",
+            date_started=dt(2023, 1, 1, 10, 0, 0),
+            method_info=self.method_info,
+        )
+
+        # Verify that default() method initializes graphs as empty dict
+        assert report_default.graphs is not None
+        assert isinstance(report_default.graphs, dict)
+        assert len(report_default.graphs) == 0


### PR DESCRIPTION
closes #20 

This PR adds the ability to export graphs in methods.

The following graph APIs are supported:

- matplotlib
- plotly

This feature essentially relies on plotly for these reasons:

- The ability to export matplotlib figures to plotly (not everything is supported, but it should be OK for now)
- The ability to serialize figures as JSON data to reload them later and generate interactive graphs or change styling

In reports, the `graphs` field has been added. It contains, for each identified figure, the figure encoded as JSON, compressed using zlib, and encoded as a base64 string.

In the HTML report viewer, the interactive plotly view is used.