### PR TITLE
Add git traceability for ingredients and catalyst

### DIFF
--- a/src/overity/backend/flow/__init__.py
+++ b/src/overity/backend/flow/__init__.py
@@ -67,6 +67,8 @@ from overity.model.report.metrics import (
     PercentageValue,
 )
 
+from overity.model.versioning import VersioningStatus
+
 from overity.exchange import report_json
 from overity.exchange.method_common import file_py, file_ipynb
 from overity.errors import (
@@ -75,6 +77,7 @@ from overity.errors import (
     NotInDMQError,
     InvalidEpochValue,
     DuplicateFigureError,
+    VersioningInconsistencyError,
 )
 
 from overity.backend.flow.ctx import FlowCtx, RunMode
@@ -199,6 +202,37 @@ def init(ctx: FlowCtx, method_path: Path, run_mode: RunMode):
     log.info(f"Add lib folder to python path: {ctx.storage.lib()}")
     sys.path.append(str(ctx.storage.lib()))
 
+    # Get versioning status and information for ingredients
+    log.info("Get versioning status and information for ingredients")
+    ingredients_version_status = ctx.storage.ingredients_version_status()
+    ingredients_version_info = (
+        ctx.storage.ingredients_version_info()
+        if ingredients_version_status != VersioningStatus.NotVersioned
+        else None
+    )
+
+    catalyst_version_status = ctx.storage.catalyst_version_status()
+    catalyst_version_info = (
+        ctx.storage.catalyst_version_info()
+        if catalyst_version_status != VersioningStatus.NotVersioned
+        else None
+    )
+
+    log.info(f"-> Ingredients versioning status: {ingredients_version_status.value}")
+    log.info(f"-> Ingredients versioning info: {ingredients_version_info!r}")
+    log.info(f"-> Catalyst versioning status: {catalyst_version_status.value}")
+    log.info(f"-> Catalyst versioning info: {catalyst_version_info!r}")
+
+    if ctx.stage == MethodExecutionStage.Operation:
+        if ingredients_version_status != VersioningStatus.Clean:
+            raise VersioningInconsistencyError()
+
+    else:
+        if ingredients_version_status != VersioningStatus.Clean:
+            log.warning(
+                f"Versioning of the ingredients folder is: {ingredients_version_status.value!r}. Traceability may not be guarenteed"
+            )
+
     # Initialize run traceability information
     # TODO: For other types
     # TODO: This is ugly.
@@ -231,6 +265,14 @@ def init(ctx: FlowCtx, method_path: Path, run_mode: RunMode):
             )
         )
 
+        # Add versioning information for method
+        if ingredients_version_info is not None:
+            ctx.report.traceability_graph.metadata_store(
+                ctx.report.method_key,
+                "commit",
+                ingredients_version_info,
+            )
+
     elif ctx.method_kind == MethodKind.MeasurementQualification:
         ctx.report.method_key = ArtifactKey(
             kind=ArtifactKind.MeasurementQualificationMethod, id=ctx.method_slug
@@ -259,6 +301,14 @@ def init(ctx: FlowCtx, method_path: Path, run_mode: RunMode):
                 kind=ArtifactLinkKind.MethodUse,
             )
         )
+
+        # Add versioning information for method
+        if ingredients_version_info is not None:
+            ctx.report.traceability_graph.metadata_store(
+                ctx.report.method_key,
+                "commit",
+                ingredients_version_info,
+            )
 
     else:
         raise NotImplementedError
@@ -313,6 +363,16 @@ def init(ctx: FlowCtx, method_path: Path, run_mode: RunMode):
                 a=ctx.report.run_key, b=k_bench, kind=ArtifactLinkKind.BenchUse
             )
         )
+
+        if ingredients_version_info is not None:
+            # TODO: Catalyst versioning info
+            ctx.report.traceability_graph.metadata_store(
+                k_bench, "commit", catalyst_version_info
+            )
+
+            ctx.report.traceability_graph.metadata_store(
+                k_abstr, "commit", ingredients_version_info
+            )
 
         # -> Log some infos
         log.info("Bench information:")

--- a/src/overity/backend/program.py
+++ b/src/overity/backend/program.py
@@ -22,6 +22,8 @@ from overity.exchange import program_toml
 
 from overity.model.general_info.program import ProgramInitiator, ProgramInfo
 
+from overity.utils.path import iter_path
+
 from datetime import date
 
 log = logging.getLogger("backend.program")
@@ -37,20 +39,6 @@ def is_program(path: Path):
     return (path / "program.toml").is_file()
 
 
-def _iter_path(pp: Path):
-    """Iterate path from cwd to filesystem root, generator style!"""
-
-    cur_path = pp
-
-    while True:
-        yield cur_path
-
-        if cur_path.parent != cur_path:
-            cur_path = cur_path.parent
-        else:
-            break
-
-
 def find_current(start_path: Path):
     log.debug(f"Search program root folder starting from {start_path}")
 
@@ -58,7 +46,7 @@ def find_current(start_path: Path):
         return start_path
 
     else:
-        for subpath in _iter_path(start_path.parent):
+        for subpath in iter_path(start_path.parent):
             log.debug(f"Check parent path: {subpath}")
 
             if is_program(subpath):

--- a/src/overity/errors.py
+++ b/src/overity/errors.py
@@ -188,3 +188,8 @@ class DuplicateFigureError(Exception):
 class NoVersionAvailable(Exception):
     def __init__(self, what: str):
         super().__init__(f"No version available for: {what}")
+
+
+class VersioningInconsistencyError(Exception):
+    def __init__(self):
+        super().__init__("Cannot guarentee versioning consistency")

--- a/src/overity/errors.py
+++ b/src/overity/errors.py
@@ -183,3 +183,8 @@ class InvalidEpochValue(Exception):
 class DuplicateFigureError(Exception):
     def __init__(self, fig_identifier: str):
         super().__init__(f"Duplicate figure identifier: {fig_identifier}")
+
+
+class NoVersionAvailable(Exception):
+    def __init__(self, what: str):
+        super().__init__(f"No version available for: {what}")

--- a/src/overity/model/versioning/__init__.py
+++ b/src/overity/model/versioning/__init__.py
@@ -1,0 +1,30 @@
+"""
+Versioning information classes
+==============================
+
+**February 2026**
+
+- Florian Dupeyron (florian.dupeyron@mugcat.fr): Initial design
+
+> This file is part of the Overity.ai project, and is licensed under
+> the terms of the Apache 2.0 license. See the LICENSE file for more
+> information.
+"""
+
+from enum import Enum
+
+
+class VersioningStatus(Enum):
+    """Indicates versioning status for a given asset.
+
+    This is primarly used for git-tracked assets (ingredients)
+    """
+
+    """No versioning information has been found for the asset"""
+    NotVersioned = "not_versioned"
+
+    """The last versioned version does not correspond to the asset the user use"""
+    Dirty = "dirty"
+
+    """The asset is correctly versioned"""
+    Clean = "clean"

--- a/src/overity/storage/base.py
+++ b/src/overity/storage/base.py
@@ -28,6 +28,8 @@ from overity.model.inference_agent.package import InferenceAgentPackageInfo
 from overity.model.dataset.metadata import DatasetMetadata
 from overity.model.dataset.package import DatasetPackageInfo
 
+from overity.model.versioning import VersioningStatus
+
 from pathlib import Path
 
 # Type alias for hashlib hash objects
@@ -78,6 +80,10 @@ class StorageBackend(ABC):
     @abstractmethod
     def lib(self):
         """Get path to directory containing additional python modules"""
+
+    @abstractmethod
+    def ingredients_version_status(self) -> VersioningStatus:
+        """Get the current versioning status of ingredients"""
 
     # -------------------------- Shelf
 

--- a/src/overity/storage/base.py
+++ b/src/overity/storage/base.py
@@ -55,6 +55,14 @@ class StorageBackend(ABC):
     def benches(self):
         """Get list of bench definitions"""
 
+    @abstractmethod
+    def catalyst_version_status(self) -> VersioningStatus:
+        """Get the current versioning status of catalyst"""
+
+    @abstractmethod
+    def catalyst_version_info(self) -> str:
+        """Get the current version information for catalyst"""
+
     # -------------------------- Ingredients
 
     @abstractmethod

--- a/src/overity/storage/base.py
+++ b/src/overity/storage/base.py
@@ -85,6 +85,10 @@ class StorageBackend(ABC):
     def ingredients_version_status(self) -> VersioningStatus:
         """Get the current versioning status of ingredients"""
 
+    @abstractmethod
+    def ingredients_version_info(self) -> str:
+        """Get the current version information for ingredients"""
+
     # -------------------------- Shelf
 
     @abstractmethod

--- a/src/overity/storage/local/__init__.py
+++ b/src/overity/storage/local/__init__.py
@@ -33,6 +33,11 @@ from overity.model.inference_agent.package import InferenceAgentPackageInfo
 from overity.model.dataset.metadata import DatasetMetadata
 from overity.model.dataset.package import DatasetPackageInfo
 
+from overity.model.versioning import VersioningStatus
+
+from overity.utils import git as git_utils
+from overity.utils import path as path_utils
+
 
 from overity.exchange import (
     execution_target_toml,
@@ -470,6 +475,51 @@ class LocalStorage(StorageBackend):
     def lib(self):
         """Return the path containing additional python modules for methods implementation"""
         return self.lib_folder
+
+    def ingredients_version_status(self) -> VersioningStatus:
+        """Get the current versioning status of the ingredients folder
+
+        Returns:
+            VersioningStatus
+
+        In local storage backend implementation, consistency is given by the git status of the "ingredients" folder.
+        So the idea is to check the git status of the ingredients folder.
+
+        1. If any change is detected within the "ingredients" folder, the version status is dirty.
+        2. If no change is detected, then the ingredients folder is clean
+        3. If there is no git repository, we cannot track the current version
+
+        TODO: How to manage when the ingredients folder is in a different git repository than the laboratory folder?
+        """
+
+        # Find the nearest repo from the ingredients folder
+        path_to_repo = git_utils.nearest_repo(self.ingredients_folder)
+
+        if path_to_repo is None:
+            return VersioningStatus.NotVersioned
+
+        # Check if the ingredients folder is actually under the found repo
+        # If not, we cannot track the version
+        try:
+            ingredients_rel = self.ingredients_folder.relative_to(path_to_repo)
+        except ValueError:
+            # ingredients folder is not under the repo root
+            return VersioningStatus.NotVersioned
+
+        # Get git status for the repository
+        git_changes = git_utils.git_status(str(path_to_repo))
+
+        # Check if any changes are within the ingredients folder
+        changes = [
+            change
+            for change in git_changes
+            if path_utils.is_subpath(Path(change.from_path), ingredients_rel)
+        ]
+
+        if changes:
+            return VersioningStatus.Dirty
+        else:
+            return VersioningStatus.Clean
 
     # -------------------------- Shelf
 

--- a/src/overity/storage/local/__init__.py
+++ b/src/overity/storage/local/__init__.py
@@ -276,6 +276,62 @@ class LocalStorage(StorageBackend):
             found_errors,
         )
 
+    def catalyst_version_status(self) -> VersioningStatus:
+        """Get the current versioning status of the catalyst folder
+
+        Returns:
+            VersioningStatus
+
+        1. If any change is detected within the "catalyst" folder, the version status is dirty.
+        2. If no change is detected, then the catalyst folder is clean
+        3. If there is no git repository, we cannot track the current version
+
+        """
+
+        # Find the nearest repo from the catalyst folder
+        path_to_repo = git_utils.nearest_repo(self.base_folder)
+
+        if path_to_repo is None:
+            return VersioningStatus.NotVersioned
+
+        # Check if the catalyst folder is actually under the found repo
+        # If not, we cannot track the version
+        try:
+            catalyst_rel = self.catalyst_folder.relative_to(path_to_repo)
+        except ValueError:
+            # catalyst folder is not under the repo root
+            return VersioningStatus.NotVersioned
+
+        # Get git status for the repository
+        git_changes = git_utils.git_status(str(path_to_repo))
+
+        # Check if any changes are within the catalyst folder
+        changes = [
+            change
+            for change in git_changes
+            if path_utils.is_subpath(Path(change.from_path), catalyst_rel)
+        ]
+
+        if changes:
+            return VersioningStatus.Dirty
+        else:
+            return VersioningStatus.Clean
+
+    def catalyst_version_info(self) -> str:
+        """Get the current version information for the catalyst folder
+
+        Returns:
+            a string that describes the used version for catalyst (e.g., git commit hash)
+
+        NOTE: if there is no versioning information available, this function raises NoVersionAvailable error
+        """
+
+        try:
+            cur_commit = git_utils.current_commit(self.base_folder)
+            return cur_commit
+        except RuntimeError:
+            raise NoVersionAvailable(f"catalyst in {str(self.catalyst_folder)!r}")
+
     # -------------------------- Ingredients
 
     def training_optimization_methods(self):

--- a/src/overity/storage/local/__init__.py
+++ b/src/overity/storage/local/__init__.py
@@ -494,7 +494,7 @@ class LocalStorage(StorageBackend):
         """
 
         # Find the nearest repo from the ingredients folder
-        path_to_repo = git_utils.nearest_repo(self.ingredients_folder)
+        path_to_repo = git_utils.nearest_repo(self.base_folder)
 
         if path_to_repo is None:
             return VersioningStatus.NotVersioned
@@ -532,7 +532,7 @@ class LocalStorage(StorageBackend):
         """
 
         try:
-            cur_commit = git_utils.current_commit(self.ingredients_folder)
+            cur_commit = git_utils.current_commit(self.base_folder)
             return cur_commit
         except RuntimeError:
             raise NoVersionAvailable(f"ingredients in {str(self.ingredients_folder)!r}")

--- a/src/overity/storage/local/__init__.py
+++ b/src/overity/storage/local/__init__.py
@@ -60,6 +60,7 @@ from overity.errors import (
     DatasetNotFound,
     ReportNotFound,
     MethodNotFound,
+    NoVersionAvailable,
 )
 
 from overity.exchange.model_package_v1 import package as ml_package
@@ -520,6 +521,21 @@ class LocalStorage(StorageBackend):
             return VersioningStatus.Dirty
         else:
             return VersioningStatus.Clean
+
+    def ingredients_version_info(self) -> str:
+        """Get the current version information for the ingredients folder
+
+        Returns:
+            a string that describes the used version for ingredients (e.g., git commit hash)
+
+        NOTE: if there is no versioning information available, this function raises NoVersionAvailable error
+        """
+
+        try:
+            cur_commit = git_utils.current_commit(self.ingredients_folder)
+            return cur_commit
+        except RuntimeError:
+            raise NoVersionAvailable(f"ingredients in {str(self.ingredients_folder)!r}")
 
     # -------------------------- Shelf
 

--- a/src/overity/utils/__init__.py
+++ b/src/overity/utils/__init__.py
@@ -1,0 +1,12 @@
+"""
+Utilities
+=========
+
+**February 2026**
+
+- Florian Dupeyron (florian.dupeyron@mugcat.fr)
+
+> This file is part of the Overity.ai project, and is licensed under
+> the terms of the Apache 2.0 license. See the LICENSE file for more
+> information.
+"""

--- a/src/overity/utils/git.py
+++ b/src/overity/utils/git.py
@@ -207,3 +207,35 @@ def farthest_repo(cwd: Path) -> Path | None:
             cur_repo = subpath
 
     return cur_repo
+
+
+def current_commit(repo_path: str | Path) -> str:
+    """Get the current commit SHA1 hash of the repository
+
+    Args:
+        repo_path: Path to the git repository
+
+    Returns:
+        The current commit SHA1 hash as a string
+
+    Raises:
+        RuntimeError: If git command is not found, or if the repo has no commits yet,
+                      or if any other git error occurs
+    """
+    cmd = ["git", "rev-parse", "HEAD"]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(repo_path),
+            encoding="utf-8",
+            errors="replace",
+        )
+    except FileNotFoundError:
+        raise RuntimeError("git command not found. Is git installed?")
+
+    if result.returncode != 0:
+        raise RuntimeError(f"git rev-parse failed: {result.stderr}")
+
+    return result.stdout.strip()

--- a/src/overity/utils/git.py
+++ b/src/overity/utils/git.py
@@ -1,0 +1,143 @@
+"""
+Git utilities
+=============
+
+**February 2026**
+
+- Florian Dupeyron (florian.dupeyron@mugcat.fr)
+
+> This file is part of the Overity.ai project, and is licensed under
+> the terms of the Apache 2.0 license. See the LICENSE file for more
+> information.
+"""
+
+from __future__ import annotations
+from typing import Self
+
+import subprocess
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class GitStatusEntryKind(Enum):
+    """Represents the type of modification in git status"""
+
+    Added = "A"
+    Modified = "M"
+    Deleted = "D"
+    Renamed = "R"
+    Copied = "C"
+    Untracked = "?"
+    Ignored = "!"
+    UpdatedButUnmerged = "U"
+
+    @classmethod
+    def try_from_str(cls, char: str) -> Self | None:
+        try:
+            return cls(char)
+        except ValueError:
+            return None
+
+
+@dataclass
+class GitStatusEntry:
+    """Represents a single git status entry"""
+
+    from_path: str
+    to_path: str | None = None
+
+    staged_kind: GitStatusEntryKind | None = None
+    unstaged_kind: GitStatusEntryKind | None = None
+
+
+def git_status(repo_path: str) -> list[GitStatusEntry]:
+    """
+    Run git status and parse the output into GitStatusEntry objects
+
+    Args:
+        repo_path: Path to the git repository
+
+    Returns:
+        List of GitStatusEntry objects representing the repository status
+    """
+
+    # Run git status command
+    cmd = ["git", "status", "--porcelain", "-z", "-uall"]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=repo_path,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except FileNotFoundError:
+        raise RuntimeError("git command not found. Is git installed?")
+
+    if result.returncode != 0:
+        raise RuntimeError(f"git status failed: {result.stderr}")
+
+    # Get the entries
+    entries = []
+    output = result.stdout
+
+    if not output:
+        return []
+
+    parts = filter(lambda x: isinstance(x, str) and (len(x) >= 3), output.split("\x00"))
+
+    for part in parts:
+        # Parse the status line
+        staged = part[0]
+        unstaged = part[1]
+
+        # Check for both staged and unstaged changes (e.g., MM, AM, MD)
+        staged_kind = GitStatusEntryKind.try_from_str(staged)
+        unstaged_kind = GitStatusEntryKind.try_from_str(unstaged)
+
+        # Get the filename(s)
+        if staged_kind in (GitStatusEntryKind.Renamed, GitStatusEntryKind.Copied):
+            # For renames and copies, git outputs: XY <new_path>\0<old_path>\0,
+            # so the first path is the destination (new), second is source (old)
+            to_path = part[3:]
+            part = next(parts)
+            from_path = part
+
+            # Add the entry
+            entries.append(
+                GitStatusEntry(
+                    staged_kind=staged_kind,
+                    unstaged_kind=unstaged_kind,
+                    from_path=from_path,
+                    to_path=to_path,
+                )
+            )
+
+        else:
+            # Regular entry with a single filename
+            from_path = part[3:]
+
+            # Note: avoid double entries for untracked and ignored entries ("??" and "!!")
+
+            entries.append(
+                GitStatusEntry(
+                    staged_kind=(
+                        staged_kind
+                        if (
+                            unstaged_kind
+                            not in (
+                                GitStatusEntryKind.Untracked,
+                                GitStatusEntryKind.Ignored,
+                            )
+                        )
+                        else None
+                    ),
+                    unstaged_kind=unstaged_kind,
+                    from_path=from_path,
+                    to_path=None,
+                )
+            )
+
+    return entries

--- a/src/overity/utils/git.py
+++ b/src/overity/utils/git.py
@@ -72,7 +72,7 @@ def git_status(repo_path: str) -> list[GitStatusEntry]:
             cmd,
             capture_output=True,
             text=True,
-            cwd=repo_path,
+            cwd=str(repo_path),
             encoding="utf-8",
             errors="replace",
         )

--- a/src/overity/utils/git.py
+++ b/src/overity/utils/git.py
@@ -16,8 +16,11 @@ from typing import Self
 
 import subprocess
 
+from pathlib import Path
 from dataclasses import dataclass
 from enum import Enum
+
+from overity.utils.path import iter_path
 
 
 class GitStatusEntryKind(Enum):
@@ -141,3 +144,66 @@ def git_status(repo_path: str) -> list[GitStatusEntry]:
             )
 
     return entries
+
+
+def is_repo(cwd: Path) -> bool:
+    """Check if the given folder has a git repo or not
+
+    Args:
+        cwd: Path to check
+
+    Returns:
+        a boolean value indicating if the folder is a git repo root or not
+
+    NOTE: This only work on "standard" git repos, not worktrees or bare repos
+    """
+
+    return (cwd / ".git").is_dir()
+
+
+def nearest_repo(cwd: Path) -> Path | None:
+    """Find the path to the nearest git repo
+
+    Args:
+        cwd: starting path
+
+    Returns:
+        Path to the nearest git repo, or None if no repo is found
+
+
+    NOTE: This method only support traditional git repos, not worktrees or bare repos
+    """
+
+    # The idea of this method is simple: Find the nearest .git folder
+    if is_repo(cwd):
+        return cwd
+
+    else:
+        for subpath in iter_path(cwd.parent):
+            if is_repo(subpath):
+                return subpath
+
+        else:
+            return None
+
+
+def farthest_repo(cwd: Path) -> Path | None:
+    """Find the repo that is the closer to the root starting from a given folder
+
+    Args:
+        cwd: starting path
+
+    Returns:
+        Path to the farthest repo, the closer to the root, or None if no repo is Found
+
+    NOTE: This method currently supports traditional git repos, not worktrees or bare repos
+    """
+
+    # The idea of this method is simple: Find the farthest .git folder
+    cur_repo = None
+
+    for subpath in iter_path(cwd):
+        if is_repo(subpath):
+            cur_repo = subpath
+
+    return cur_repo

--- a/src/overity/utils/path.py
+++ b/src/overity/utils/path.py
@@ -1,0 +1,37 @@
+"""
+Overity.ai path manipulation utilities
+======================================
+
+**February 2026**
+
+- Florian Dupeyron (florian.dupeyron@mugcat.fr): Initial design
+
+> This file is part of the Overity.ai project, and is licensed under
+> the terms of the Apache 2.0 license. See the LICENSE file for more
+> information.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def iter_path(pp: Path):
+    """Iterate path from cwd to filesystem root, generator style!
+
+    Args:
+        pp: Starting path
+
+    Returns:
+        A generator that iterates through paths, starting from current folder
+    """
+
+    cur_path = pp
+
+    while True:
+        yield cur_path
+
+        if cur_path.parent != cur_path:
+            cur_path = cur_path.parent
+        else:
+            break

--- a/src/overity/utils/path.py
+++ b/src/overity/utils/path.py
@@ -35,3 +35,22 @@ def iter_path(pp: Path):
             cur_path = cur_path.parent
         else:
             break
+
+
+def is_subpath(a: Path, b: Path) -> bool:
+    """Check if a is a child of b
+
+    Args:
+        a: Path to check (the potential subpath)
+        b: base Path (the potential parent)
+    Returns:
+        a boolean indicating if a is a sub-path of b
+
+    NOTE: This is quite hacky, I think there is a better way to do this
+    """
+
+    try:
+        Path(a).relative_to(Path(b))
+        return True
+    except ValueError:  # Raised if is not a sub-path
+        return False

--- a/tests/test_storage_local_catalyst_version_status.py
+++ b/tests/test_storage_local_catalyst_version_status.py
@@ -1,0 +1,392 @@
+"""
+Unit tests for catalyst_version_status and catalyst_version_info functions
+Uses real git repositories in temporary folders for integration testing
+"""
+
+import subprocess
+import pytest
+import tempfile
+import shutil
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from overity.storage.local import LocalStorage
+from overity.model.versioning import VersioningStatus
+from overity.errors import NoVersionAvailable
+
+
+def run_git(args, cwd=None):
+    """Helper to run git commands"""
+    result = subprocess.run(
+        ["git"] + args, cwd=str(cwd) if cwd else None, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git command failed: {result.stderr}")
+    return result
+
+
+def create_git_repo(path, with_commit=True):
+    """Create a git repository at the given path"""
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    run_git(["init"], cwd=path)
+    run_git(["config", "user.email", "test@test.com"], cwd=path)
+    run_git(["config", "user.name", "Test User"], cwd=path)
+
+    if with_commit:
+        # Create initial commit
+        (path / "README.md").write_text("# Test repo")
+        run_git(["add", "README.md"], cwd=path)
+        run_git(["commit", "-m", "Initial commit"], cwd=path)
+
+    return path
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for tests"""
+    tmp = tempfile.mkdtemp()
+    yield Path(tmp)
+    shutil.rmtree(tmp)
+
+
+class TestCatalystVersionStatusIntegration:
+    """Integration tests for catalyst_version_status with real git repos"""
+
+    def test_clean_no_changes_real_repo(self, temp_dir):
+        """Test when catalyst folder is clean in a real git repo"""
+        # Create a repo with catalyst folder
+        create_git_repo(temp_dir)
+        catalyst_dir = temp_dir / "catalyst"
+        catalyst_dir.mkdir()
+        (catalyst_dir / "bench.toml").write_text("[bench]")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "Add catalyst"], cwd=temp_dir)
+
+        storage = LocalStorage(temp_dir)
+        result = storage.catalyst_version_status()
+
+        assert result == VersioningStatus.Clean
+
+    def test_dirty_with_uncommitted_changes_real_repo(self, temp_dir):
+        """Test when there are uncommitted changes in catalyst"""
+        # Create a repo with catalyst folder
+        create_git_repo(temp_dir)
+        catalyst_dir = temp_dir / "catalyst"
+        catalyst_dir.mkdir()
+        (catalyst_dir / "bench.toml").write_text("[bench]")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "Add catalyst"], cwd=temp_dir)
+
+        # Add uncommitted change
+        (catalyst_dir / "bench.toml").write_text('[bench]\nname = "test"')
+
+        storage = LocalStorage(temp_dir)
+        result = storage.catalyst_version_status()
+
+        assert result == VersioningStatus.Dirty
+
+    def test_clean_changes_outside_catalyst_real_repo(self, temp_dir):
+        """Test that changes outside catalyst don't affect status"""
+        create_git_repo(temp_dir)
+
+        # Create catalyst folder
+        catalyst_dir = temp_dir / "catalyst"
+        catalyst_dir.mkdir()
+        (catalyst_dir / "bench.toml").write_text("[bench]")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "Add catalyst"], cwd=temp_dir)
+
+        # Add file outside catalyst
+        (temp_dir / "other.txt").write_text("other content")
+        run_git(["add", "other.txt"], cwd=temp_dir)
+
+        storage = LocalStorage(temp_dir)
+        result = storage.catalyst_version_status()
+
+        assert result == VersioningStatus.Clean
+
+    def test_not_versioned_no_git_repo_real(self, temp_dir):
+        """Test when there is no git repository"""
+        # Just create a folder without git
+        (temp_dir / "catalyst").mkdir()
+        (temp_dir / "catalyst" / "file.txt").write_text("content")
+
+        storage = LocalStorage(temp_dir)
+        result = storage.catalyst_version_status()
+
+        assert result == VersioningStatus.NotVersioned
+
+    def test_catalyst_is_git_submodule_clean_real(self, temp_dir):
+        """Test when catalyst folder is a git submodule (clean)"""
+        # Create parent repo
+        create_git_repo(temp_dir)
+
+        # Create catalyst as a separate repo (will be submodule)
+        catalyst_dir = temp_dir / "catalyst"
+        create_git_repo(catalyst_dir)
+        (catalyst_dir / "bench.toml").write_text("[bench]")
+        run_git(["add", "."], cwd=catalyst_dir)
+        run_git(["commit", "-m", "Add bench"], cwd=catalyst_dir)
+
+        # Add the submodule folder to parent repo
+        run_git(["add", "catalyst"], cwd=temp_dir)
+        run_git(["commit", "-m", "Add catalyst submodule"], cwd=temp_dir)
+
+        storage = LocalStorage(temp_dir)
+        result = storage.catalyst_version_status()
+
+        assert result == VersioningStatus.Clean
+
+    def test_catalyst_is_git_submodule_dirty_real(self, temp_dir):
+        """Test when catalyst folder is a git submodule (dirty)"""
+        # Create parent repo
+        create_git_repo(temp_dir)
+
+        # Create catalyst as a separate repo (will be submodule)
+        catalyst_dir = temp_dir / "catalyst"
+        create_git_repo(catalyst_dir)
+        (catalyst_dir / "bench.toml").write_text("[bench]")
+        run_git(["add", "."], cwd=catalyst_dir)
+        run_git(["commit", "-m", "Add bench"], cwd=catalyst_dir)
+
+        # Make uncommitted change
+        (catalyst_dir / "bench.toml").write_text('[bench]\nname = "modified"')
+
+        storage = LocalStorage(temp_dir)
+        result = storage.catalyst_version_status()
+
+        assert result == VersioningStatus.Dirty
+
+
+class TestCatalystVersionInfoIntegration:
+    """Integration tests for catalyst_version_info with real git repos"""
+
+    def test_returns_real_commit_hash(self, temp_dir):
+        """Test returning an actual git commit hash"""
+        create_git_repo(temp_dir)
+        (temp_dir / "file.txt").write_text("content")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "Initial commit"], cwd=temp_dir)
+
+        # Get the actual commit hash
+        result = run_git(["rev-parse", "HEAD"], cwd=temp_dir)
+        expected_hash = result.stdout.strip()
+
+        storage = LocalStorage(temp_dir)
+        version_info = storage.catalyst_version_info()
+
+        assert version_info == expected_hash
+        assert len(version_info) == 40  # SHA-1 hash length
+
+    def test_returns_different_hash_after_new_commit(self, temp_dir):
+        """Test that new commits return different hashes"""
+        create_git_repo(temp_dir)
+        (temp_dir / "file.txt").write_text("content")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "First commit"], cwd=temp_dir)
+
+        storage = LocalStorage(temp_dir)
+        hash1 = storage.catalyst_version_info()
+
+        # Make another commit
+        (temp_dir / "file.txt").write_text("modified content")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "Second commit"], cwd=temp_dir)
+
+        hash2 = storage.catalyst_version_info()
+
+        assert hash1 != hash2
+        assert len(hash1) == 40
+        assert len(hash2) == 40
+
+    def test_raises_no_version_available_no_git_real(self, temp_dir):
+        """Test raising NoVersionAvailable when no git repo exists"""
+        # Create a folder without git
+        (temp_dir / "catalyst").mkdir()
+
+        storage = LocalStorage(temp_dir)
+        with pytest.raises(NoVersionAvailable):
+            storage.catalyst_version_info()
+
+    def test_raises_no_version_available_no_commits_real(self, temp_dir):
+        """Test raising NoVersionAvailable when repo has no commits"""
+        # Create repo but don't make any commits
+        create_git_repo(temp_dir, with_commit=False)
+
+        storage = LocalStorage(temp_dir)
+        with pytest.raises(NoVersionAvailable):
+            storage.catalyst_version_info()
+
+    def test_returns_commit_from_parent_repo_when_catalyst_is_submodule(self, temp_dir):
+        """Test that version info comes from parent repo, not submodule"""
+        # Create parent repo
+        create_git_repo(temp_dir)
+
+        # Create catalyst as a submodule with its own repo
+        catalyst_dir = temp_dir / "catalyst"
+        create_git_repo(catalyst_dir)
+        (catalyst_dir / "bench.toml").write_text("[bench]")
+        run_git(["add", "."], cwd=catalyst_dir)
+        run_git(["commit", "-m", "Add bench"], cwd=catalyst_dir)
+
+        # Add catalyst to parent and commit
+        run_git(["add", "catalyst"], cwd=temp_dir)
+        run_git(["commit", "-m", "Add catalyst submodule"], cwd=temp_dir)
+
+        # Get the parent repo commit hash (not the submodule's)
+        result = run_git(["rev-parse", "HEAD"], cwd=temp_dir)
+        expected_parent_hash = result.stdout.strip()
+
+        storage = LocalStorage(temp_dir)
+        version_info = storage.catalyst_version_info()
+
+        # The implementation uses base_folder, so it returns the parent's commit
+        assert version_info == expected_parent_hash
+
+        # Verify it's different from the submodule's commit
+        submodule_hash = run_git(["rev-parse", "HEAD"], cwd=catalyst_dir).stdout.strip()
+        assert version_info != submodule_hash
+
+
+# Unit tests for edge cases using mocks
+class TestCatalystVersionStatus:
+    """Unit tests for catalyst_version_status function"""
+
+    def test_not_versioned_no_git_repo(self):
+        """Test when there is no git repository"""
+        with patch("overity.storage.local.git_utils.nearest_repo") as mock_nearest:
+            mock_nearest.return_value = None
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.catalyst_version_status()
+
+            assert result == VersioningStatus.NotVersioned
+            mock_nearest.assert_called_once_with(storage.base_folder)
+
+    def test_clean_no_changes(self):
+        """Test when catalyst folder is clean (no changes)"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status:
+            # Mock that we found a repo at the catalyst folder itself
+            mock_nearest.return_value = Path("/test/program/catalyst")
+
+            # No changes in git status
+            mock_git_status.return_value = []
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.catalyst_version_status()
+
+            assert result == VersioningStatus.Clean
+            mock_nearest.assert_called_once_with(storage.base_folder)
+            mock_git_status.assert_called_once_with(str(Path("/test/program/catalyst")))
+
+    def test_clean_changes_outside_catalyst(self):
+        """Test when there are changes but outside catalyst folder"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status, patch(
+            "overity.storage.local.path_utils.is_subpath"
+        ) as mock_is_subpath:
+            mock_nearest.return_value = Path("/test/program")
+
+            # Create mock changes outside catalyst folder
+            mock_change = MagicMock()
+            mock_change.from_path = "other_folder/file.txt"
+            mock_git_status.return_value = [mock_change]
+
+            # is_subpath returns False for changes outside catalyst
+            mock_is_subpath.return_value = False
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.catalyst_version_status()
+
+            assert result == VersioningStatus.Clean
+
+    def test_dirty_changes_inside_catalyst(self):
+        """Test when there are changes inside catalyst folder"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status, patch(
+            "overity.storage.local.path_utils.is_subpath"
+        ) as mock_is_subpath:
+            mock_nearest.return_value = Path("/test/program")
+
+            # Create mock changes inside catalyst folder
+            mock_change = MagicMock()
+            mock_change.from_path = "catalyst/bench.toml"
+            mock_git_status.return_value = [mock_change]
+
+            # is_subpath returns True for changes inside catalyst
+            mock_is_subpath.return_value = True
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.catalyst_version_status()
+
+            assert result == VersioningStatus.Dirty
+
+    def test_catalyst_not_under_repo(self):
+        """Test when catalyst folder is not under the found repo"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status:
+            # The repo is at a completely different location from catalyst
+            mock_nearest.return_value = Path("/other/repo")
+
+            storage = LocalStorage(Path("/test/program"))
+
+            # The catalyst folder is /test/program/catalyst, which is not under /other/repo
+            # So catalyst.relative_to(/other/repo) should raise ValueError
+            try:
+                storage.catalyst_folder.relative_to(Path("/other/repo"))
+                # If we get here, the paths happen to work (depends on filesystem)
+                result = storage.catalyst_version_status()
+                assert result in [VersioningStatus.Clean, VersioningStatus.Dirty]
+            except ValueError:
+                # This is the expected case - catalyst is not under the repo
+                result = storage.catalyst_version_status()
+                assert result == VersioningStatus.NotVersioned
+                # git_status should not be called since catalyst is not under repo
+                mock_git_status.assert_not_called()
+
+
+class TestCatalystVersionInfo:
+    """Unit tests for catalyst_version_info function"""
+
+    def test_raises_no_version_available_no_git(self):
+        """Test raising NoVersionAvailable when git command fails"""
+        with patch(
+            "overity.storage.local.git_utils.current_commit"
+        ) as mock_current_commit:
+            mock_current_commit.side_effect = RuntimeError("git command not found")
+
+            storage = LocalStorage(Path("/test/program"))
+            with pytest.raises(NoVersionAvailable) as exc_info:
+                storage.catalyst_version_info()
+
+            assert "catalyst" in str(exc_info.value)
+            assert "/test/program/catalyst" in str(exc_info.value)
+
+    def test_path_passed_correctly_to_current_commit(self):
+        """Test that catalyst folder path is passed correctly to current_commit"""
+        with patch(
+            "overity.storage.local.git_utils.current_commit"
+        ) as mock_current_commit:
+            mock_current_commit.return_value = "abc123" + "0" * 36
+
+            storage = LocalStorage(Path("/some/deeply/nested/program/path"))
+            storage.catalyst_version_info()
+
+            # Verify the correct path was passed
+            mock_current_commit.assert_called_once()
+            call_args = mock_current_commit.call_args[0][0]
+            assert str(call_args) == "/some/deeply/nested/program/path"

--- a/tests/test_storage_local_ingredients_version_status.py
+++ b/tests/test_storage_local_ingredients_version_status.py
@@ -1,8 +1,12 @@
 """
-Unit tests for ingredients_version_status function
+Unit tests for ingredients_version_status and ingredients_version_info functions
+Uses real git repositories in temporary folders for integration testing
 """
 
+import subprocess
 import pytest
+import tempfile
+import shutil
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -11,8 +15,262 @@ from overity.model.versioning import VersioningStatus
 from overity.errors import NoVersionAvailable
 
 
+def run_git(args, cwd=None):
+    """Helper to run git commands"""
+    result = subprocess.run(
+        ["git"] + args, cwd=str(cwd) if cwd else None, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git command failed: {result.stderr}")
+    return result
+
+
+def create_git_repo(path, with_commit=True):
+    """Create a git repository at the given path"""
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    run_git(["init"], cwd=path)
+    run_git(["config", "user.email", "test@test.com"], cwd=path)
+    run_git(["config", "user.name", "Test User"], cwd=path)
+
+    if with_commit:
+        # Create initial commit
+        (path / "README.md").write_text("# Test repo")
+        run_git(["add", "README.md"], cwd=path)
+        run_git(["commit", "-m", "Initial commit"], cwd=path)
+
+    return path
+
+
+def create_git_submodule(parent_path, submodule_name, with_commit=True):
+    """Create a git submodule within a parent repo"""
+    submodule_path = parent_path / submodule_name
+    create_git_repo(submodule_path, with_commit=with_commit)
+
+    # Add as submodule to parent
+    run_git(["submodule", "add", str(submodule_path), submodule_name], cwd=parent_path)
+    run_git(["commit", "-m", f"Add {submodule_name} submodule"], cwd=parent_path)
+
+    return submodule_path
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for tests"""
+    tmp = tempfile.mkdtemp()
+    yield Path(tmp)
+    shutil.rmtree(tmp)
+
+
+class TestIngredientsVersionStatusIntegration:
+    """Integration tests for ingredients_version_status with real git repos"""
+
+    def test_clean_no_changes_real_repo(self, temp_dir):
+        """Test when ingredients folder is clean in a real git repo"""
+        # Create a repo with ingredients folder
+        create_git_repo(temp_dir)
+        ingredients_dir = temp_dir / "ingredients"
+        ingredients_dir.mkdir()
+        (ingredients_dir / "method.py").write_text("# method")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "Add ingredients"], cwd=temp_dir)
+
+        storage = LocalStorage(temp_dir)
+        result = storage.ingredients_version_status()
+
+        assert result == VersioningStatus.Clean
+
+    def test_dirty_with_uncommitted_changes_real_repo(self, temp_dir):
+        """Test when there are uncommitted changes in ingredients"""
+        # Create a repo with ingredients folder
+        create_git_repo(temp_dir)
+        ingredients_dir = temp_dir / "ingredients"
+        ingredients_dir.mkdir()
+        (ingredients_dir / "method.py").write_text("# method")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "Add ingredients"], cwd=temp_dir)
+
+        # Add uncommitted change
+        (ingredients_dir / "method.py").write_text("# modified method")
+
+        storage = LocalStorage(temp_dir)
+        result = storage.ingredients_version_status()
+
+        assert result == VersioningStatus.Dirty
+
+    def test_clean_changes_outside_ingredients_real_repo(self, temp_dir):
+        """Test that changes outside ingredients don't affect status"""
+        create_git_repo(temp_dir)
+
+        # Create ingredients folder
+        ingredients_dir = temp_dir / "ingredients"
+        ingredients_dir.mkdir()
+        (ingredients_dir / "method.py").write_text("# method")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "Add ingredients"], cwd=temp_dir)
+
+        # Add file outside ingredients
+        (temp_dir / "other.txt").write_text("other content")
+        run_git(["add", "other.txt"], cwd=temp_dir)
+
+        storage = LocalStorage(temp_dir)
+        result = storage.ingredients_version_status()
+
+        assert result == VersioningStatus.Clean
+
+    def test_not_versioned_no_git_repo_real(self, temp_dir):
+        """Test when there is no git repository"""
+        # Just create a folder without git
+        (temp_dir / "ingredients").mkdir()
+        (temp_dir / "ingredients" / "file.txt").write_text("content")
+
+        storage = LocalStorage(temp_dir)
+        result = storage.ingredients_version_status()
+
+        assert result == VersioningStatus.NotVersioned
+
+    def test_ingredients_is_git_submodule_clean_real(self, temp_dir):
+        """Test when ingredients folder is a git submodule (clean)"""
+        # Create parent repo
+        create_git_repo(temp_dir)
+
+        # Create ingredients as a separate repo (will be submodule)
+        ingredients_dir = temp_dir / "ingredients"
+        create_git_repo(ingredients_dir)
+        (ingredients_dir / "method.py").write_text("# method")
+        run_git(["add", "."], cwd=ingredients_dir)
+        run_git(["commit", "-m", "Add method"], cwd=ingredients_dir)
+
+        # Add the submodule folder to parent repo
+        # Note: We don't use git submodule add here, just track the folder
+        # The ingredients folder itself is a separate repo
+        # For the test to be clean, we need to commit the submodule reference
+        run_git(["add", "ingredients"], cwd=temp_dir)
+        run_git(["commit", "-m", "Add ingredients submodule"], cwd=temp_dir)
+
+        storage = LocalStorage(temp_dir)
+        result = storage.ingredients_version_status()
+
+        assert result == VersioningStatus.Clean
+
+    def test_ingredients_is_git_submodule_dirty_real(self, temp_dir):
+        """Test when ingredients folder is a git submodule (dirty)"""
+        # Create parent repo
+        create_git_repo(temp_dir)
+
+        # Create ingredients as a separate repo (will be submodule)
+        ingredients_dir = temp_dir / "ingredients"
+        create_git_repo(ingredients_dir)
+        (ingredients_dir / "method.py").write_text("# method")
+        run_git(["add", "."], cwd=ingredients_dir)
+        run_git(["commit", "-m", "Add method"], cwd=ingredients_dir)
+
+        # Make uncommitted change
+        (ingredients_dir / "method.py").write_text("# modified method")
+
+        storage = LocalStorage(temp_dir)
+        result = storage.ingredients_version_status()
+
+        assert result == VersioningStatus.Dirty
+
+
+class TestIngredientsVersionInfoIntegration:
+    """Integration tests for ingredients_version_info with real git repos"""
+
+    def test_returns_real_commit_hash(self, temp_dir):
+        """Test returning an actual git commit hash"""
+        create_git_repo(temp_dir)
+        (temp_dir / "file.txt").write_text("content")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "Initial commit"], cwd=temp_dir)
+
+        # Get the actual commit hash
+        result = run_git(["rev-parse", "HEAD"], cwd=temp_dir)
+        expected_hash = result.stdout.strip()
+
+        storage = LocalStorage(temp_dir)
+        version_info = storage.ingredients_version_info()
+
+        assert version_info == expected_hash
+        assert len(version_info) == 40  # SHA-1 hash length
+
+    def test_returns_different_hash_after_new_commit(self, temp_dir):
+        """Test that new commits return different hashes"""
+        create_git_repo(temp_dir)
+        (temp_dir / "file.txt").write_text("content")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "First commit"], cwd=temp_dir)
+
+        storage = LocalStorage(temp_dir)
+        hash1 = storage.ingredients_version_info()
+
+        # Make another commit
+        (temp_dir / "file.txt").write_text("modified content")
+        run_git(["add", "."], cwd=temp_dir)
+        run_git(["commit", "-m", "Second commit"], cwd=temp_dir)
+
+        hash2 = storage.ingredients_version_info()
+
+        assert hash1 != hash2
+        assert len(hash1) == 40
+        assert len(hash2) == 40
+
+    def test_raises_no_version_available_no_git_real(self, temp_dir):
+        """Test raising NoVersionAvailable when no git repo exists"""
+        # Create a folder without git
+        (temp_dir / "ingredients").mkdir()
+
+        storage = LocalStorage(temp_dir)
+        with pytest.raises(NoVersionAvailable):
+            storage.ingredients_version_info()
+
+    def test_raises_no_version_available_no_commits_real(self, temp_dir):
+        """Test raising NoVersionAvailable when repo has no commits"""
+        # Create repo but don't make any commits
+        create_git_repo(temp_dir, with_commit=False)
+
+        storage = LocalStorage(temp_dir)
+        with pytest.raises(NoVersionAvailable):
+            storage.ingredients_version_info()
+
+    def test_returns_commit_from_parent_repo_when_ingredients_is_submodule(
+        self, temp_dir
+    ):
+        """Test that version info comes from parent repo, not submodule"""
+        # Create parent repo
+        create_git_repo(temp_dir)
+
+        # Create ingredients as a submodule with its own repo
+        ingredients_dir = temp_dir / "ingredients"
+        create_git_repo(ingredients_dir)
+        (ingredients_dir / "method.py").write_text("# method")
+        run_git(["add", "."], cwd=ingredients_dir)
+        run_git(["commit", "-m", "Add method"], cwd=ingredients_dir)
+
+        # Add ingredients to parent and commit
+        run_git(["add", "ingredients"], cwd=temp_dir)
+        run_git(["commit", "-m", "Add ingredients submodule"], cwd=temp_dir)
+
+        # Get the parent repo commit hash (not the submodule's)
+        result = run_git(["rev-parse", "HEAD"], cwd=temp_dir)
+        expected_parent_hash = result.stdout.strip()
+
+        storage = LocalStorage(temp_dir)
+        version_info = storage.ingredients_version_info()
+
+        # The implementation uses base_folder, so it returns the parent's commit
+        assert version_info == expected_parent_hash
+
+        # Verify it's different from the submodule's commit
+        submodule_hash = run_git(
+            ["rev-parse", "HEAD"], cwd=ingredients_dir
+        ).stdout.strip()
+        assert version_info != submodule_hash
+
+
+# Keep existing mocked unit tests for edge cases
 class TestIngredientsVersionStatus:
-    """Tests for ingredients_version_status function"""
+    """Unit tests for ingredients_version_status function"""
 
     def test_not_versioned_no_git_repo(self):
         """Test when there is no git repository"""
@@ -23,7 +281,7 @@ class TestIngredientsVersionStatus:
             result = storage.ingredients_version_status()
 
             assert result == VersioningStatus.NotVersioned
-            mock_nearest.assert_called_once_with(storage.ingredients_folder)
+            mock_nearest.assert_called_once_with(storage.base_folder)
 
     def test_clean_no_changes(self):
         """Test when ingredients folder is clean (no changes)"""
@@ -42,7 +300,7 @@ class TestIngredientsVersionStatus:
             result = storage.ingredients_version_status()
 
             assert result == VersioningStatus.Clean
-            mock_nearest.assert_called_once_with(storage.ingredients_folder)
+            mock_nearest.assert_called_once_with(storage.base_folder)
             mock_git_status.assert_called_once_with(
                 str(Path("/test/program/ingredients"))
             )
@@ -95,58 +353,6 @@ class TestIngredientsVersionStatus:
 
             assert result == VersioningStatus.Dirty
 
-    def test_dirty_multiple_changes_some_inside(self):
-        """Test when some changes are inside and some outside ingredients"""
-        with patch(
-            "overity.storage.local.git_utils.nearest_repo"
-        ) as mock_nearest, patch(
-            "overity.storage.local.git_utils.git_status"
-        ) as mock_git_status, patch(
-            "overity.storage.local.path_utils.is_subpath"
-        ) as mock_is_subpath:
-            mock_nearest.return_value = Path("/test/program")
-
-            # Create mock changes - one inside, one outside
-            mock_change1 = MagicMock()
-            mock_change1.from_path = "other_folder/file.txt"
-            mock_change2 = MagicMock()
-            mock_change2.from_path = "ingredients/measurement_qualification/test.py"
-            mock_git_status.return_value = [mock_change1, mock_change2]
-
-            # First call (outside) returns False, second call (inside) returns True
-            mock_is_subpath.side_effect = [False, True]
-
-            storage = LocalStorage(Path("/test/program"))
-            result = storage.ingredients_version_status()
-
-            assert result == VersioningStatus.Dirty
-            assert mock_is_subpath.call_count == 2
-
-    def test_ingredients_at_repo_root(self):
-        """Test when ingredients folder is at the repo root"""
-        with patch(
-            "overity.storage.local.git_utils.nearest_repo"
-        ) as mock_nearest, patch(
-            "overity.storage.local.git_utils.git_status"
-        ) as mock_git_status, patch(
-            "overity.storage.local.path_utils.is_subpath"
-        ) as mock_is_subpath:
-            # Ingredients folder IS the repo root
-            mock_nearest.return_value = Path("/test/program/ingredients")
-
-            # Some changes in the repo
-            mock_change = MagicMock()
-            mock_change.from_path = "training_optimization/new_method.py"
-            mock_git_status.return_value = [mock_change]
-
-            # All changes are within ingredients (since ingredients is the root)
-            mock_is_subpath.return_value = True
-
-            storage = LocalStorage(Path("/test/program"))
-            result = storage.ingredients_version_status()
-
-            assert result == VersioningStatus.Dirty
-
     def test_ingredients_not_under_repo(self):
         """Test when ingredients folder is not under the found repo"""
         with patch(
@@ -176,93 +382,9 @@ class TestIngredientsVersionStatus:
                 # git_status should not be called since ingredients is not under repo
                 mock_git_status.assert_not_called()
 
-    def test_repo_in_parent_directory(self):
-        """Test when repo is in a parent directory of ingredients"""
-        with patch(
-            "overity.storage.local.git_utils.nearest_repo"
-        ) as mock_nearest, patch(
-            "overity.storage.local.git_utils.git_status"
-        ) as mock_git_status, patch(
-            "overity.storage.local.path_utils.is_subpath"
-        ) as mock_is_subpath:
-            # Repo is two levels up from ingredients
-            mock_nearest.return_value = Path("/test")
-
-            # Changes in various locations
-            mock_change = MagicMock()
-            mock_change.from_path = "program/ingredients/lib/helper.py"
-            mock_git_status.return_value = [mock_change]
-
-            mock_is_subpath.return_value = True
-
-            storage = LocalStorage(Path("/test/program"))
-            result = storage.ingredients_version_status()
-
-            assert result == VersioningStatus.Dirty
-            # Verify git_status was called with the repo path
-            mock_git_status.assert_called_once_with("/test")
-
-    def test_empty_git_status_clean(self):
-        """Test that empty git status results in Clean"""
-        with patch(
-            "overity.storage.local.git_utils.nearest_repo"
-        ) as mock_nearest, patch(
-            "overity.storage.local.git_utils.git_status"
-        ) as mock_git_status:
-            mock_nearest.return_value = Path("/test/program")
-            mock_git_status.return_value = []
-
-            storage = LocalStorage(Path("/test/program"))
-            result = storage.ingredients_version_status()
-
-            assert result == VersioningStatus.Clean
-
-    def test_all_changes_filtered_out_clean(self):
-        """Test when all changes are outside ingredients folder"""
-        with patch(
-            "overity.storage.local.git_utils.nearest_repo"
-        ) as mock_nearest, patch(
-            "overity.storage.local.git_utils.git_status"
-        ) as mock_git_status, patch(
-            "overity.storage.local.path_utils.is_subpath"
-        ) as mock_is_subpath:
-            mock_nearest.return_value = Path("/test/program")
-
-            # Multiple changes but all outside ingredients
-            mock_changes = [
-                MagicMock(from_path="shelf/report.json"),
-                MagicMock(from_path="catalyst/bench.toml"),
-                MagicMock(from_path="README.md"),
-            ]
-            mock_git_status.return_value = mock_changes
-
-            # All changes are outside ingredients
-            mock_is_subpath.return_value = False
-
-            storage = LocalStorage(Path("/test/program"))
-            result = storage.ingredients_version_status()
-
-            assert result == VersioningStatus.Clean
-            assert mock_is_subpath.call_count == 3
-
 
 class TestIngredientsVersionInfo:
-    """Tests for ingredients_version_info function"""
-
-    def test_returns_commit_hash_success(self):
-        """Test successfully returning the current commit hash"""
-        with patch(
-            "overity.storage.local.git_utils.current_commit"
-        ) as mock_current_commit:
-            expected_hash = "abc123def456789012345678901234567890abcd"
-            mock_current_commit.return_value = expected_hash
-
-            storage = LocalStorage(Path("/test/program"))
-            result = storage.ingredients_version_info()
-
-            assert result == expected_hash
-            assert len(result) == 40
-            mock_current_commit.assert_called_once_with(storage.ingredients_folder)
+    """Unit tests for ingredients_version_info function"""
 
     def test_raises_no_version_available_no_git(self):
         """Test raising NoVersionAvailable when git command fails"""
@@ -278,40 +400,6 @@ class TestIngredientsVersionInfo:
             assert "ingredients" in str(exc_info.value)
             assert "/test/program/ingredients" in str(exc_info.value)
 
-    def test_raises_no_version_available_no_commits(self):
-        """Test raising NoVersionAvailable when repo has no commits"""
-        with patch(
-            "overity.storage.local.git_utils.current_commit"
-            # 1
-        ) as mock_current_commit:
-            mock_current_commit.side_effect = RuntimeError(
-                "git rev-parse failed: fatal: not a git repository"
-            )
-
-            storage = LocalStorage(Path("/test/program"))
-            with pytest.raises(NoVersionAvailable):
-                storage.ingredients_version_info()
-
-    def test_returns_different_hash_for_different_commits(self):
-        """Test that different commits return different hashes"""
-        with patch(
-            "overity.storage.local.git_utils.current_commit"
-        ) as mock_current_commit:
-            commit1 = "abc123def456789012345678901234567890abcd"
-            commit2 = "def789abc123456789012345678901234567890a"
-
-            # First call returns commit1, second call returns commit2
-            mock_current_commit.side_effect = [commit1, commit2]
-
-            storage = LocalStorage(Path("/test/program"))
-
-            result1 = storage.ingredients_version_info()
-            result2 = storage.ingredients_version_info()
-
-            assert result1 == commit1
-            assert result2 == commit2
-            assert result1 != result2
-
     def test_path_passed_correctly_to_current_commit(self):
         """Test that ingredients folder path is passed correctly to current_commit"""
         with patch(
@@ -325,4 +413,4 @@ class TestIngredientsVersionInfo:
             # Verify the correct path was passed
             mock_current_commit.assert_called_once()
             call_args = mock_current_commit.call_args[0][0]
-            assert str(call_args) == "/some/deeply/nested/program/path/ingredients"
+            assert str(call_args) == "/some/deeply/nested/program/path"

--- a/tests/test_storage_local_ingredients_version_status.py
+++ b/tests/test_storage_local_ingredients_version_status.py
@@ -1,0 +1,245 @@
+"""
+Unit tests for ingredients_version_status function
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from overity.storage.local import LocalStorage
+from overity.model.versioning import VersioningStatus
+
+
+class TestIngredientsVersionStatus:
+    """Tests for ingredients_version_status function"""
+
+    def test_not_versioned_no_git_repo(self):
+        """Test when there is no git repository"""
+        with patch("overity.storage.local.git_utils.nearest_repo") as mock_nearest:
+            mock_nearest.return_value = None
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.ingredients_version_status()
+
+            assert result == VersioningStatus.NotVersioned
+            mock_nearest.assert_called_once_with(storage.ingredients_folder)
+
+    def test_clean_no_changes(self):
+        """Test when ingredients folder is clean (no changes)"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status:
+            # Mock that we found a repo at the ingredients folder itself
+            mock_nearest.return_value = Path("/test/program/ingredients")
+
+            # No changes in git status
+            mock_git_status.return_value = []
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.ingredients_version_status()
+
+            assert result == VersioningStatus.Clean
+            mock_nearest.assert_called_once_with(storage.ingredients_folder)
+            mock_git_status.assert_called_once_with(
+                str(Path("/test/program/ingredients"))
+            )
+
+    def test_clean_changes_outside_ingredients(self):
+        """Test when there are changes but outside ingredients folder"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status, patch(
+            "overity.storage.local.path_utils.is_subpath"
+        ) as mock_is_subpath:
+            mock_nearest.return_value = Path("/test/program")
+
+            # Create mock changes outside ingredients folder
+            mock_change = MagicMock()
+            mock_change.from_path = "other_folder/file.txt"
+            mock_git_status.return_value = [mock_change]
+
+            # is_subpath returns False for changes outside ingredients
+            mock_is_subpath.return_value = False
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.ingredients_version_status()
+
+            assert result == VersioningStatus.Clean
+
+    def test_dirty_changes_inside_ingredients(self):
+        """Test when there are changes inside ingredients folder"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status, patch(
+            "overity.storage.local.path_utils.is_subpath"
+        ) as mock_is_subpath:
+            mock_nearest.return_value = Path("/test/program")
+
+            # Create mock changes inside ingredients folder
+            mock_change = MagicMock()
+            mock_change.from_path = "ingredients/training_optimization/method.py"
+            mock_git_status.return_value = [mock_change]
+
+            # is_subpath returns True for changes inside ingredients
+            mock_is_subpath.return_value = True
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.ingredients_version_status()
+
+            assert result == VersioningStatus.Dirty
+
+    def test_dirty_multiple_changes_some_inside(self):
+        """Test when some changes are inside and some outside ingredients"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status, patch(
+            "overity.storage.local.path_utils.is_subpath"
+        ) as mock_is_subpath:
+            mock_nearest.return_value = Path("/test/program")
+
+            # Create mock changes - one inside, one outside
+            mock_change1 = MagicMock()
+            mock_change1.from_path = "other_folder/file.txt"
+            mock_change2 = MagicMock()
+            mock_change2.from_path = "ingredients/measurement_qualification/test.py"
+            mock_git_status.return_value = [mock_change1, mock_change2]
+
+            # First call (outside) returns False, second call (inside) returns True
+            mock_is_subpath.side_effect = [False, True]
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.ingredients_version_status()
+
+            assert result == VersioningStatus.Dirty
+            assert mock_is_subpath.call_count == 2
+
+    def test_ingredients_at_repo_root(self):
+        """Test when ingredients folder is at the repo root"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status, patch(
+            "overity.storage.local.path_utils.is_subpath"
+        ) as mock_is_subpath:
+            # Ingredients folder IS the repo root
+            mock_nearest.return_value = Path("/test/program/ingredients")
+
+            # Some changes in the repo
+            mock_change = MagicMock()
+            mock_change.from_path = "training_optimization/new_method.py"
+            mock_git_status.return_value = [mock_change]
+
+            # All changes are within ingredients (since ingredients is the root)
+            mock_is_subpath.return_value = True
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.ingredients_version_status()
+
+            assert result == VersioningStatus.Dirty
+
+    def test_ingredients_not_under_repo(self):
+        """Test when ingredients folder is not under the found repo"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status:
+            # The repo is at a completely different location from ingredients
+            mock_nearest.return_value = Path("/other/repo")
+
+            storage = LocalStorage(Path("/test/program"))
+
+            # The ingredients folder is /test/program/ingredients, which is not under /other/repo
+            # So ingredients.relative_to(/other/repo) should raise ValueError
+            # We test this by checking the actual behavior
+            try:
+                storage.ingredients_folder.relative_to(Path("/other/repo"))
+                # If we get here, the paths happen to work (depends on filesystem)
+                # In that case, the test will call git_status, which is fine
+                # Just verify we get a valid result
+                result = storage.ingredients_version_status()
+                assert result in [VersioningStatus.Clean, VersioningStatus.Dirty]
+            except ValueError:
+                # This is the expected case - ingredients is not under the repo
+                result = storage.ingredients_version_status()
+                assert result == VersioningStatus.NotVersioned
+                # git_status should not be called since ingredients is not under repo
+                mock_git_status.assert_not_called()
+
+    def test_repo_in_parent_directory(self):
+        """Test when repo is in a parent directory of ingredients"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status, patch(
+            "overity.storage.local.path_utils.is_subpath"
+        ) as mock_is_subpath:
+            # Repo is two levels up from ingredients
+            mock_nearest.return_value = Path("/test")
+
+            # Changes in various locations
+            mock_change = MagicMock()
+            mock_change.from_path = "program/ingredients/lib/helper.py"
+            mock_git_status.return_value = [mock_change]
+
+            mock_is_subpath.return_value = True
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.ingredients_version_status()
+
+            assert result == VersioningStatus.Dirty
+            # Verify git_status was called with the repo path
+            mock_git_status.assert_called_once_with("/test")
+
+    def test_empty_git_status_clean(self):
+        """Test that empty git status results in Clean"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status:
+            mock_nearest.return_value = Path("/test/program")
+            mock_git_status.return_value = []
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.ingredients_version_status()
+
+            assert result == VersioningStatus.Clean
+
+    def test_all_changes_filtered_out_clean(self):
+        """Test when all changes are outside ingredients folder"""
+        with patch(
+            "overity.storage.local.git_utils.nearest_repo"
+        ) as mock_nearest, patch(
+            "overity.storage.local.git_utils.git_status"
+        ) as mock_git_status, patch(
+            "overity.storage.local.path_utils.is_subpath"
+        ) as mock_is_subpath:
+            mock_nearest.return_value = Path("/test/program")
+
+            # Multiple changes but all outside ingredients
+            mock_changes = [
+                MagicMock(from_path="shelf/report.json"),
+                MagicMock(from_path="catalyst/bench.toml"),
+                MagicMock(from_path="README.md"),
+            ]
+            mock_git_status.return_value = mock_changes
+
+            # All changes are outside ingredients
+            mock_is_subpath.return_value = False
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.ingredients_version_status()
+
+            assert result == VersioningStatus.Clean
+            assert mock_is_subpath.call_count == 3

--- a/tests/test_storage_local_ingredients_version_status.py
+++ b/tests/test_storage_local_ingredients_version_status.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, MagicMock
 
 from overity.storage.local import LocalStorage
 from overity.model.versioning import VersioningStatus
+from overity.errors import NoVersionAvailable
 
 
 class TestIngredientsVersionStatus:
@@ -243,3 +244,85 @@ class TestIngredientsVersionStatus:
 
             assert result == VersioningStatus.Clean
             assert mock_is_subpath.call_count == 3
+
+
+class TestIngredientsVersionInfo:
+    """Tests for ingredients_version_info function"""
+
+    def test_returns_commit_hash_success(self):
+        """Test successfully returning the current commit hash"""
+        with patch(
+            "overity.storage.local.git_utils.current_commit"
+        ) as mock_current_commit:
+            expected_hash = "abc123def456789012345678901234567890abcd"
+            mock_current_commit.return_value = expected_hash
+
+            storage = LocalStorage(Path("/test/program"))
+            result = storage.ingredients_version_info()
+
+            assert result == expected_hash
+            assert len(result) == 40
+            mock_current_commit.assert_called_once_with(storage.ingredients_folder)
+
+    def test_raises_no_version_available_no_git(self):
+        """Test raising NoVersionAvailable when git command fails"""
+        with patch(
+            "overity.storage.local.git_utils.current_commit"
+        ) as mock_current_commit:
+            mock_current_commit.side_effect = RuntimeError("git command not found")
+
+            storage = LocalStorage(Path("/test/program"))
+            with pytest.raises(NoVersionAvailable) as exc_info:
+                storage.ingredients_version_info()
+
+            assert "ingredients" in str(exc_info.value)
+            assert "/test/program/ingredients" in str(exc_info.value)
+
+    def test_raises_no_version_available_no_commits(self):
+        """Test raising NoVersionAvailable when repo has no commits"""
+        with patch(
+            "overity.storage.local.git_utils.current_commit"
+            # 1
+        ) as mock_current_commit:
+            mock_current_commit.side_effect = RuntimeError(
+                "git rev-parse failed: fatal: not a git repository"
+            )
+
+            storage = LocalStorage(Path("/test/program"))
+            with pytest.raises(NoVersionAvailable):
+                storage.ingredients_version_info()
+
+    def test_returns_different_hash_for_different_commits(self):
+        """Test that different commits return different hashes"""
+        with patch(
+            "overity.storage.local.git_utils.current_commit"
+        ) as mock_current_commit:
+            commit1 = "abc123def456789012345678901234567890abcd"
+            commit2 = "def789abc123456789012345678901234567890a"
+
+            # First call returns commit1, second call returns commit2
+            mock_current_commit.side_effect = [commit1, commit2]
+
+            storage = LocalStorage(Path("/test/program"))
+
+            result1 = storage.ingredients_version_info()
+            result2 = storage.ingredients_version_info()
+
+            assert result1 == commit1
+            assert result2 == commit2
+            assert result1 != result2
+
+    def test_path_passed_correctly_to_current_commit(self):
+        """Test that ingredients folder path is passed correctly to current_commit"""
+        with patch(
+            "overity.storage.local.git_utils.current_commit"
+        ) as mock_current_commit:
+            mock_current_commit.return_value = "abc123" + "0" * 36
+
+            storage = LocalStorage(Path("/some/deeply/nested/program/path"))
+            storage.ingredients_version_info()
+
+            # Verify the correct path was passed
+            mock_current_commit.assert_called_once()
+            call_args = mock_current_commit.call_args[0][0]
+            assert str(call_args) == "/some/deeply/nested/program/path/ingredients"

--- a/tests/test_utils_git.py
+++ b/tests/test_utils_git.py
@@ -11,6 +11,9 @@ from overity.utils.git import (
     GitStatusEntryKind,
     GitStatusEntry,
     git_status,
+    nearest_repo,
+    farthest_repo,
+    current_commit,
 )
 
 
@@ -47,7 +50,10 @@ class TestCharToKind:
 
     def test_updated_but_unmerged(self):
         """Test 'U' maps to UpdatedButUnmerged"""
-        assert GitStatusEntryKind.try_from_str("U") == GitStatusEntryKind.UpdatedButUnmerged
+        assert (
+            GitStatusEntryKind.try_from_str("U")
+            == GitStatusEntryKind.UpdatedButUnmerged
+        )
 
     def test_invalid_char(self):
         """Test invalid character returns None"""
@@ -100,9 +106,9 @@ class TestGitStatus:
         """Test detecting untracked files"""
         # Create an untracked file
         (temp_git_repo / "untracked.txt").write_text("hello")
-        
+
         result = git_status(str(temp_git_repo))
-        
+
         assert len(result) == 1
         assert result[0].from_path == "untracked.txt"
         assert result[0].staged_kind is None
@@ -119,9 +125,9 @@ class TestGitStatus:
             capture_output=True,
             check=True,
         )
-        
+
         result = git_status(str(temp_git_repo))
-        
+
         assert len(result) == 1
         assert result[0].from_path == "staged.txt"
         assert result[0].staged_kind == GitStatusEntryKind.Added
@@ -144,9 +150,9 @@ class TestGitStatus:
             check=True,
         )
         (temp_git_repo / "modified.txt").write_text("modified")
-        
+
         result = git_status(str(temp_git_repo))
-        
+
         assert len(result) == 1
         assert result[0].from_path == "modified.txt"
         assert result[0].staged_kind is None
@@ -177,9 +183,9 @@ class TestGitStatus:
             check=True,
         )
         (temp_git_repo / "both.txt").write_text("modified after stage")
-        
+
         result = git_status(str(temp_git_repo))
-        
+
         assert len(result) == 1
         assert result[0].from_path == "both.txt"
         assert result[0].staged_kind == GitStatusEntryKind.Modified
@@ -202,9 +208,9 @@ class TestGitStatus:
             check=True,
         )
         (temp_git_repo / "deleted.txt").unlink()
-        
+
         result = git_status(str(temp_git_repo))
-        
+
         assert len(result) == 1
         assert result[0].from_path == "deleted.txt"
         assert result[0].staged_kind is None
@@ -233,9 +239,9 @@ class TestGitStatus:
             capture_output=True,
             check=True,
         )
-        
+
         result = git_status(str(temp_git_repo))
-        
+
         assert len(result) == 1
         assert result[0].from_path == "staged_del.txt"
         assert result[0].staged_kind == GitStatusEntryKind.Deleted
@@ -263,9 +269,9 @@ class TestGitStatus:
             capture_output=True,
             check=True,
         )
-        
+
         result = git_status(str(temp_git_repo))
-        
+
         assert len(result) == 1
         assert result[0].from_path == "old_name.txt"
         assert result[0].to_path == "new_name.txt"
@@ -276,7 +282,7 @@ class TestGitStatus:
         # Create multiple files
         (temp_git_repo / "file1.txt").write_text("file1")
         (temp_git_repo / "file2.txt").write_text("file2")
-        
+
         # Stage file1
         subprocess.run(
             ["git", "add", "file1.txt"],
@@ -284,9 +290,9 @@ class TestGitStatus:
             capture_output=True,
             check=True,
         )
-        
+
         result = git_status(str(temp_git_repo))
-        
+
         assert len(result) == 2
         paths = {entry.from_path for entry in result}
         assert paths == {"file1.txt", "file2.txt"}
@@ -301,3 +307,247 @@ class TestGitStatus:
         with tempfile.TemporaryDirectory() as tmpdir:
             with pytest.raises(RuntimeError):
                 git_status(tmpdir)
+
+
+class TestNearestRepo:
+    """Tests for nearest_repo function"""
+
+    def test_current_dir_is_repo(self, temp_git_repo):
+        """Test when current directory is already the repo root"""
+        result = nearest_repo(temp_git_repo)
+        assert result == temp_git_repo
+
+    def test_subdir_of_repo(self, temp_git_repo):
+        """Test finding repo from a subdirectory"""
+        subdir = temp_git_repo / "subdir" / "nested"
+        subdir.mkdir(parents=True)
+
+        result = nearest_repo(subdir)
+        assert result == temp_git_repo
+
+    def test_deeply_nested_subdir(self, temp_git_repo):
+        """Test finding repo from a deeply nested subdirectory"""
+        subdir = temp_git_repo / "a" / "b" / "c" / "d"
+        subdir.mkdir(parents=True)
+
+        result = nearest_repo(subdir)
+        assert result == temp_git_repo
+
+    def test_no_repo_found(self):
+        """Test when no repo exists in parent directories"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            start_dir = Path(tmpdir) / "start"
+            start_dir.mkdir()
+
+            result = nearest_repo(start_dir)
+            assert result is None
+
+    def test_nested_repos_finds_nearest(self):
+        """Test that nested repos find the nearest one"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            # Create outer repo
+            outer_repo = root / "outer"
+            outer_repo.mkdir()
+            subprocess.run(
+                ["git", "init"], cwd=outer_repo, capture_output=True, check=True
+            )
+
+            # Create inner repo
+            inner_repo = outer_repo / "inner"
+            inner_repo.mkdir()
+            subprocess.run(
+                ["git", "init"], cwd=inner_repo, capture_output=True, check=True
+            )
+
+            # From inside inner repo, should find inner repo
+            subdir = inner_repo / "subdir"
+            subdir.mkdir()
+            result = nearest_repo(subdir)
+            assert result == inner_repo
+
+
+class TestFarthestRepo:
+    """Tests for farthest_repo function"""
+
+    def test_current_dir_is_repo(self, temp_git_repo):
+        """Test when current directory is already the repo root"""
+        result = farthest_repo(temp_git_repo)
+        assert result == temp_git_repo
+
+    def test_subdir_of_repo(self, temp_git_repo):
+        """Test finding repo from a subdirectory"""
+        subdir = temp_git_repo / "subdir" / "nested"
+        subdir.mkdir(parents=True)
+
+        result = farthest_repo(subdir)
+        assert result == temp_git_repo
+
+    def test_no_repo_found(self):
+        """Test when no repo exists"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            start_dir = Path(tmpdir) / "start"
+            start_dir.mkdir()
+
+            result = farthest_repo(start_dir)
+            assert result is None
+
+    def test_nested_repos_finds_farthest(self):
+        """Test that nested repos find the farthest (outermost) one"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            # Create outer repo
+            outer_repo = root / "outer"
+            outer_repo.mkdir()
+            subprocess.run(
+                ["git", "init"], cwd=outer_repo, capture_output=True, check=True
+            )
+
+            # Create inner repo
+            inner_repo = outer_repo / "inner"
+            inner_repo.mkdir()
+            subprocess.run(
+                ["git", "init"], cwd=inner_repo, capture_output=True, check=True
+            )
+
+            # From inside inner repo subdir, should find outer repo (farthest)
+            subdir = inner_repo / "subdir"
+            subdir.mkdir()
+            result = farthest_repo(subdir)
+            assert result == outer_repo
+
+    def test_deeply_nested_repos(self):
+        """Test finding farthest repo with deeply nested structure"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            # Create repos at multiple levels
+            level1 = root / "level1"
+            level1.mkdir()
+            subprocess.run(["git", "init"], cwd=level1, capture_output=True, check=True)
+
+            level2 = level1 / "level2"
+            level2.mkdir()
+            subprocess.run(["git", "init"], cwd=level2, capture_output=True, check=True)
+
+            level3 = level2 / "level3"
+            level3.mkdir()
+            subprocess.run(["git", "init"], cwd=level3, capture_output=True, check=True)
+
+            # From level3, should find level1 as farthest
+            subdir = level3 / "subdir"
+            subdir.mkdir()
+            result = farthest_repo(subdir)
+            assert result == level1
+
+
+class TestCurrentCommit:
+    """Tests for current_commit function"""
+
+    def test_get_commit_hash(self, temp_git_repo):
+        """Test getting commit hash from repo with commits"""
+        # Create and commit a file
+        (temp_git_repo / "test.txt").write_text("test content")
+        subprocess.run(
+            ["git", "add", "test.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Test commit"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        result = current_commit(temp_git_repo)
+
+        # SHA1 should be 40 hex characters
+        assert len(result) == 40
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_no_commits_raises_error(self, temp_git_repo):
+        """Test that repo with no commits raises RuntimeError"""
+        with pytest.raises(RuntimeError):
+            current_commit(temp_git_repo)
+
+    def test_multiple_commits_gets_latest(self, temp_git_repo):
+        """Test that we get the latest commit hash"""
+        # Create first commit
+        (temp_git_repo / "file1.txt").write_text("content1")
+        subprocess.run(
+            ["git", "add", "file1.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "First commit"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        first_hash = current_commit(temp_git_repo)
+
+        # Create second commit
+        (temp_git_repo / "file2.txt").write_text("content2")
+        subprocess.run(
+            ["git", "add", "file2.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Second commit"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        second_hash = current_commit(temp_git_repo)
+
+        # Second hash should be different from first
+        assert second_hash != first_hash
+        assert len(second_hash) == 40
+
+    def test_subdir_path(self, temp_git_repo):
+        """Test getting commit from a subdirectory of the repo"""
+        # Create and commit a file
+        (temp_git_repo / "test.txt").write_text("test content")
+        subprocess.run(
+            ["git", "add", "test.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Test commit"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+
+        # Create a subdirectory and test from there
+        subdir = temp_git_repo / "subdir"
+        subdir.mkdir()
+
+        result = current_commit(subdir)
+
+        # Should still work from subdirectory
+        assert len(result) == 40
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_nonexistent_path_raises_error(self):
+        """Test that non-existent path raises RuntimeError"""
+        with pytest.raises(RuntimeError):
+            current_commit("/nonexistent/path/that/does/not/exist")
+
+    def test_not_git_repo_raises_error(self):
+        """Test that non-git directory raises RuntimeError"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(RuntimeError):
+                current_commit(tmpdir)

--- a/tests/test_utils_git.py
+++ b/tests/test_utils_git.py
@@ -1,0 +1,303 @@
+"""
+Unit tests for utils/git.py
+"""
+
+import pytest
+import tempfile
+import subprocess
+from pathlib import Path
+
+from overity.utils.git import (
+    GitStatusEntryKind,
+    GitStatusEntry,
+    git_status,
+)
+
+
+class TestCharToKind:
+    """Tests for GitStatusEntryKind.try_from_str function"""
+
+    def test_added(self):
+        """Test 'A' maps to Added"""
+        assert GitStatusEntryKind.try_from_str("A") == GitStatusEntryKind.Added
+
+    def test_modified(self):
+        """Test 'M' maps to Modified"""
+        assert GitStatusEntryKind.try_from_str("M") == GitStatusEntryKind.Modified
+
+    def test_deleted(self):
+        """Test 'D' maps to Deleted"""
+        assert GitStatusEntryKind.try_from_str("D") == GitStatusEntryKind.Deleted
+
+    def test_renamed(self):
+        """Test 'R' maps to Renamed"""
+        assert GitStatusEntryKind.try_from_str("R") == GitStatusEntryKind.Renamed
+
+    def test_copied(self):
+        """Test 'C' maps to Copied"""
+        assert GitStatusEntryKind.try_from_str("C") == GitStatusEntryKind.Copied
+
+    def test_untracked(self):
+        """Test '?' maps to Untracked"""
+        assert GitStatusEntryKind.try_from_str("?") == GitStatusEntryKind.Untracked
+
+    def test_ignored(self):
+        """Test '!' maps to Ignored"""
+        assert GitStatusEntryKind.try_from_str("!") == GitStatusEntryKind.Ignored
+
+    def test_updated_but_unmerged(self):
+        """Test 'U' maps to UpdatedButUnmerged"""
+        assert GitStatusEntryKind.try_from_str("U") == GitStatusEntryKind.UpdatedButUnmerged
+
+    def test_invalid_char(self):
+        """Test invalid character returns None"""
+        assert GitStatusEntryKind.try_from_str("X") is None
+        assert GitStatusEntryKind.try_from_str(" ") is None
+        assert GitStatusEntryKind.try_from_str("") is None
+
+    def test_space_char(self):
+        """Test space character returns None"""
+        assert GitStatusEntryKind.try_from_str(" ") is None
+
+
+@pytest.fixture
+def temp_git_repo():
+    """Create a temporary git repository for testing"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_path = Path(tmpdir)
+        # Initialize git repo
+        subprocess.run(
+            ["git", "init"],
+            cwd=repo_path,
+            capture_output=True,
+            check=True,
+        )
+        # Configure git user for commits
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            capture_output=True,
+            check=True,
+        )
+        yield repo_path
+
+
+class TestGitStatus:
+    """Tests for git_status function"""
+
+    def test_clean_repo(self, temp_git_repo):
+        """Test that a clean repo returns empty list"""
+        result = git_status(str(temp_git_repo))
+        assert result == []
+
+    def test_untracked_file(self, temp_git_repo):
+        """Test detecting untracked files"""
+        # Create an untracked file
+        (temp_git_repo / "untracked.txt").write_text("hello")
+        
+        result = git_status(str(temp_git_repo))
+        
+        assert len(result) == 1
+        assert result[0].from_path == "untracked.txt"
+        assert result[0].staged_kind is None
+        assert result[0].unstaged_kind == GitStatusEntryKind.Untracked
+        assert result[0].to_path is None
+
+    def test_staged_file(self, temp_git_repo):
+        """Test detecting staged files"""
+        # Create and stage a file
+        (temp_git_repo / "staged.txt").write_text("hello")
+        subprocess.run(
+            ["git", "add", "staged.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        
+        result = git_status(str(temp_git_repo))
+        
+        assert len(result) == 1
+        assert result[0].from_path == "staged.txt"
+        assert result[0].staged_kind == GitStatusEntryKind.Added
+        assert result[0].unstaged_kind is None
+
+    def test_modified_file(self, temp_git_repo):
+        """Test detecting modified files"""
+        # Create, commit, then modify a file
+        (temp_git_repo / "modified.txt").write_text("original")
+        subprocess.run(
+            ["git", "add", "modified.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        (temp_git_repo / "modified.txt").write_text("modified")
+        
+        result = git_status(str(temp_git_repo))
+        
+        assert len(result) == 1
+        assert result[0].from_path == "modified.txt"
+        assert result[0].staged_kind is None
+        assert result[0].unstaged_kind == GitStatusEntryKind.Modified
+
+    def test_staged_and_modified(self, temp_git_repo):
+        """Test detecting staged and modified files (MM status)"""
+        # Create, commit, then modify a file
+        (temp_git_repo / "both.txt").write_text("original")
+        subprocess.run(
+            ["git", "add", "both.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        # Stage and then modify
+        (temp_git_repo / "both.txt").write_text("staged version")
+        subprocess.run(
+            ["git", "add", "both.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        (temp_git_repo / "both.txt").write_text("modified after stage")
+        
+        result = git_status(str(temp_git_repo))
+        
+        assert len(result) == 1
+        assert result[0].from_path == "both.txt"
+        assert result[0].staged_kind == GitStatusEntryKind.Modified
+        assert result[0].unstaged_kind == GitStatusEntryKind.Modified
+
+    def test_deleted_file(self, temp_git_repo):
+        """Test detecting deleted files"""
+        # Create and commit a file, then delete it
+        (temp_git_repo / "deleted.txt").write_text("to be deleted")
+        subprocess.run(
+            ["git", "add", "deleted.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        (temp_git_repo / "deleted.txt").unlink()
+        
+        result = git_status(str(temp_git_repo))
+        
+        assert len(result) == 1
+        assert result[0].from_path == "deleted.txt"
+        assert result[0].staged_kind is None
+        assert result[0].unstaged_kind == GitStatusEntryKind.Deleted
+
+    def test_staged_deleted_file(self, temp_git_repo):
+        """Test detecting staged deleted files"""
+        # Create, commit, then stage deletion
+        (temp_git_repo / "staged_del.txt").write_text("to be deleted")
+        subprocess.run(
+            ["git", "add", "staged_del.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        (temp_git_repo / "staged_del.txt").unlink()
+        subprocess.run(
+            ["git", "add", "staged_del.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        
+        result = git_status(str(temp_git_repo))
+        
+        assert len(result) == 1
+        assert result[0].from_path == "staged_del.txt"
+        assert result[0].staged_kind == GitStatusEntryKind.Deleted
+        assert result[0].unstaged_kind is None
+
+    def test_renamed_file(self, temp_git_repo):
+        """Test detecting renamed files"""
+        # Create and commit a file, then rename it
+        (temp_git_repo / "old_name.txt").write_text("content")
+        subprocess.run(
+            ["git", "add", "old_name.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "mv", "old_name.txt", "new_name.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        
+        result = git_status(str(temp_git_repo))
+        
+        assert len(result) == 1
+        assert result[0].from_path == "old_name.txt"
+        assert result[0].to_path == "new_name.txt"
+        assert result[0].staged_kind == GitStatusEntryKind.Renamed
+
+    def test_multiple_files(self, temp_git_repo):
+        """Test detecting multiple files with different statuses"""
+        # Create multiple files
+        (temp_git_repo / "file1.txt").write_text("file1")
+        (temp_git_repo / "file2.txt").write_text("file2")
+        
+        # Stage file1
+        subprocess.run(
+            ["git", "add", "file1.txt"],
+            cwd=temp_git_repo,
+            capture_output=True,
+            check=True,
+        )
+        
+        result = git_status(str(temp_git_repo))
+        
+        assert len(result) == 2
+        paths = {entry.from_path for entry in result}
+        assert paths == {"file1.txt", "file2.txt"}
+
+    def test_nonexistent_path(self):
+        """Test that non-existent path raises RuntimeError"""
+        with pytest.raises(RuntimeError):
+            git_status("/nonexistent/path/that/does/not/exist")
+
+    def test_not_git_repo(self):
+        """Test that non-git directory raises RuntimeError"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with pytest.raises(RuntimeError):
+                git_status(tmpdir)

--- a/tests/test_utils_path.py
+++ b/tests/test_utils_path.py
@@ -1,0 +1,200 @@
+"""
+Unit tests for utils/path.py
+"""
+
+import pytest
+import tempfile
+from pathlib import Path
+
+from overity.utils.path import iter_path, is_subpath
+
+
+class TestIterPath:
+    """Tests for iter_path function"""
+
+    def test_iterates_to_root(self):
+        """Test that iter_path iterates from current to root"""
+        path = Path("/a/b/c/d")
+        paths = list(iter_path(path))
+
+        assert len(paths) == 5
+        assert paths[0] == Path("/a/b/c/d")
+        assert paths[1] == Path("/a/b/c")
+        assert paths[2] == Path("/a/b")
+        assert paths[3] == Path("/a")
+        assert paths[4] == Path("/")
+
+    def test_single_component(self):
+        """Test with single path component"""
+        path = Path("/")
+        paths = list(iter_path(path))
+
+        assert len(paths) == 1
+        assert paths[0] == Path("/")
+
+    def test_relative_path(self):
+        """Test with relative path"""
+        path = Path("a/b/c")
+        paths = list(iter_path(path))
+
+        assert len(paths) == 4
+        assert paths[0] == Path("a/b/c")
+        assert paths[1] == Path("a/b")
+        assert paths[2] == Path("a")
+        assert paths[3] == Path(".")
+
+
+class TestIsSubpath:
+    """Tests for is_subpath function with absolute paths"""
+
+    def test_direct_child_absolute(self):
+        """Test when a is direct child of b (absolute paths)"""
+        a = Path("/home/user/projects/myapp")
+        b = Path("/home/user/projects")
+        assert is_subpath(a, b) is True
+
+    def test_nested_child_absolute(self):
+        """Test when a is nested deeply under b (absolute paths)"""
+        a = Path("/home/user/projects/myapp/src/components")
+        b = Path("/home/user")
+        assert is_subpath(a, b) is True
+
+    def test_same_path_absolute(self):
+        """Test when a and b are the same (absolute paths)"""
+        a = Path("/home/user/projects")
+        b = Path("/home/user/projects")
+        assert is_subpath(a, b) is True
+
+    def test_not_subpath_absolute(self):
+        """Test when a is not under b (absolute paths)"""
+        a = Path("/home/user/projects")
+        b = Path("/var/log")
+        assert is_subpath(a, b) is False
+
+    def test_sibling_paths_absolute(self):
+        """Test sibling paths (absolute)"""
+        a = Path("/home/user/projects/myapp")
+        b = Path("/home/user/documents")
+        assert is_subpath(a, b) is False
+
+    def test_partial_match_absolute(self):
+        """Test when path names partially match but aren't related (absolute)"""
+        a = Path("/home/user2/projects")
+        b = Path("/home/user")
+        assert is_subpath(a, b) is False
+
+    def test_child_of_root_absolute(self):
+        """Test direct child of root (absolute)"""
+        a = Path("/home")
+        b = Path("/")
+        assert is_subpath(a, b) is True
+
+    def test_root_is_subpath_of_root_absolute(self):
+        """Test root is subpath of itself (absolute)"""
+        a = Path("/")
+        b = Path("/")
+        assert is_subpath(a, b) is True
+
+
+class TestIsSubpathRelative:
+    """Tests for is_subpath function with relative paths"""
+
+    def test_direct_child_relative(self):
+        """Test when a is direct child of b (relative paths)"""
+        a = Path("projects/myapp")
+        b = Path("projects")
+        assert is_subpath(a, b) is True
+
+    def test_nested_child_relative(self):
+        """Test when a is nested deeply under b (relative paths)"""
+        a = Path("src/components/buttons")
+        b = Path("src")
+        assert is_subpath(a, b) is True
+
+    def test_same_path_relative(self):
+        """Test when a and b are the same (relative paths)"""
+        a = Path("projects/myapp")
+        b = Path("projects/myapp")
+        assert is_subpath(a, b) is True
+
+    def test_not_subpath_relative(self):
+        """Test when a is not under b (relative paths)"""
+        a = Path("projects/myapp")
+        b = Path("documents/reports")
+        assert is_subpath(a, b) is False
+
+    def test_sibling_paths_relative(self):
+        """Test sibling paths (relative)"""
+        a = Path("src/components")
+        b = Path("tests/unit")
+        assert is_subpath(a, b) is False
+
+    def test_going_up_relative(self):
+        """Test when a goes up from b (relative paths)"""
+        a = Path("..")
+        b = Path("src/components")
+        assert is_subpath(a, b) is False
+
+    def test_single_component_relative(self):
+        """Test single component relative paths"""
+        a = Path("src")
+        b = Path(".")
+        assert is_subpath(a, b) is True
+
+    def test_dot_current_directory(self):
+        """Test with current directory"""
+        a = Path("./src/components")
+        b = Path(".")
+        assert is_subpath(a, b) is True
+
+
+class TestIsSubpathMixed:
+    """Tests for is_subpath function with mixed absolute/relative paths"""
+
+    def test_absolute_a_relative_b(self):
+        """Test absolute a with relative b"""
+        a = Path("/home/user/projects")
+        b = Path("home/user")
+        # This will fail because absolute vs relative don't mix well
+        assert is_subpath(a, b) is False
+
+    def test_relative_a_absolute_b(self):
+        """Test relative a with absolute b"""
+        a = Path("projects/myapp")
+        b = Path("/home/user")
+        assert is_subpath(a, b) is False
+
+
+class TestIsSubpathWithRealFilesystem:
+    """Tests for is_subpath with actual filesystem paths"""
+
+    def test_real_subpath(self, tmp_path):
+        """Test with real directory structure"""
+        # Create nested directories
+        nested = tmp_path / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+
+        assert is_subpath(nested, tmp_path) is True
+        assert is_subpath(nested, tmp_path / "a") is True
+        assert is_subpath(nested, tmp_path / "a" / "b") is True
+
+    def test_real_not_subpath(self, tmp_path):
+        """Test paths that exist but aren't related"""
+        dir1 = tmp_path / "dir1"
+        dir2 = tmp_path / "dir2"
+        dir1.mkdir()
+        dir2.mkdir()
+
+        assert is_subpath(dir1, dir2) is False
+        assert is_subpath(dir2, dir1) is False
+
+    def test_real_file_path(self, tmp_path):
+        """Test with file paths"""
+        nested_dir = tmp_path / "src" / "utils"
+        nested_dir.mkdir(parents=True)
+        file_path = nested_dir / "helpers.py"
+        file_path.write_text("# helper functions")
+
+        assert is_subpath(file_path, tmp_path) is True
+        assert is_subpath(file_path, nested_dir) is True
+        assert is_subpath(file_path, tmp_path / "tests") is False


### PR DESCRIPTION
closes #2 

This feature adds the missing traceability for `catalyst` (general information) and `ingredients` (methods for optimizing, training, testing and analyzing).

The main idea behind this feature is to ensure the "versioning status" of all ingredients and catalyst through the storage backend implementation. The versioning information is given by the git repo's current commit sha1.

Multiple edge-cases can occur:

- The `ingredients` or `catalyst` folder is in a git sub-module
- The `ingredients` or `catalyst` folder is in a git repo and not the program root

etc.

So the main strategy is to fetch versioning information from the closest-repo from the program's root directory. As the specific used commit is specified in the super-repo, so we know that if a specific commit sha1 is given, we should be able to re-create the specific configuration that has been used.