### PR TITLE
Model attachment feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,8 @@ source_pkgs = ["overity", "tests"]
 branch      = true
 parallel    = true
 omit        = [
-	"src/overity/__about__.py"
+	"src/overity/__about__.py",
+	"tests/*.py"
 ]
 
 [tool.coverage.paths]
@@ -180,3 +181,6 @@ code-headers     = "scripts/header_check.py src"
 
 # Linting report using SARIF format for automation
 code-rules-sarif = "ruff check src --output-format sarif -o .lint.sarif"
+
+# Fix code rules
+code-rules-fix   = "ruff check src --fix"

--- a/src/overity/backend/flow/__init__.py
+++ b/src/overity/backend/flow/__init__.py
@@ -623,7 +623,7 @@ def model_use(ctx, slug: str):
     tmpdir = tempfile.TemporaryDirectory()
     tmpdir_path = Path(tmpdir.name).resolve()
 
-    pkginfo, sha256 = ctx.storage.model_load(slug, tmpdir_path)
+    pkginfo, sha256, attachments = ctx.storage.model_load(slug, tmpdir_path)
 
     # Add traceability
     # -> Create artifact key for model
@@ -648,7 +648,7 @@ def model_use(ctx, slug: str):
 
     ctx.tmpdirs.append(tmpdir)
 
-    return tmpdir_path / pkginfo.model_file, pkginfo
+    return tmpdir_path / pkginfo.model_file, pkginfo, attachments
 
 
 @_api_guard

--- a/src/overity/backend/flow/__init__.py
+++ b/src/overity/backend/flow/__init__.py
@@ -23,7 +23,6 @@ from pathlib import Path
 from functools import partial
 
 from datetime import datetime as dt
-from dataclasses import dataclass
 
 from overity.backend import program
 from overity.backend import bench as b_bench
@@ -82,6 +81,7 @@ from overity.errors import (
     DuplicateFigureError,
     VersioningInconsistencyError,
 )
+from overity.exchange.model_package_v1 import attachment as exch_attachment
 
 from overity.backend.flow.ctx import FlowCtx, RunMode
 from overity.backend.flow import environment as b_env
@@ -129,11 +129,107 @@ class LoggerWriter:
         pass
 
 
-@dataclass
-class ModelPackageInfo:
-    model_metadata: MLModelMetadata
-    model_file_path: Path  # Path to store model file
-    inference_example_path: Path  # Optional folder path to store inference example
+# @dataclass
+# class ModelPackageInfo:
+#    """Metadata of the saved model"""
+#    metadata: MLModelMetadata
+#
+#    """Path to store the model file"""
+#    model_file: Path
+#
+#    """Temporary folder to save the attachments files"""
+#    attachments_dir: Path
+#
+#    """Temporary folder to save inference example"""
+#    inference_example_dir: Path
+#
+#    """List of attachment specifications"""
+#    attachments: tuple[Path, str | None]
+
+
+class ModelPackageBuilder:
+    def __init__(
+        self,
+        slug: str,
+        tmpdir: Path | str,
+        exchange_format: str,
+        version: str,
+        target: str = "agnostic",
+    ):
+        self.slug = slug
+        self.version = version
+        self.tmpdir = Path(tmpdir)
+        self.exchange_format = exchange_format
+        self.target = target
+
+        self.authors = []
+        self.maintainers = []
+        self.attachments = []
+
+        self.model_file = self.tmpdir / f"model.{exchange_format}"
+        self.attachments_dir = self.tmpdir / "attachments"
+        self.inference_example_dir = self.tmpdir / "inference-example"
+
+    # ----------------------------- Initialization
+
+    def folders_create(self):
+        self.attachments_dir.mkdir(parents=True)
+        self.inference_example_dir.mkdir(parents=True)
+
+    # ----------------------------- Metadata tools
+
+    def author_add(self, name: str, email: str, contribution: str | None = None):
+        self.authors.append(
+            MLModelAuthor(name=name, email=email, contribution=contribution)
+        )
+
+    def maintainer_add(self, name: str, email: str):
+        self.maintainers.append(
+            MLModelMaintainer(
+                name=name,
+                email=email,
+            )
+        )
+
+    # ----------------------------- Attachments tools
+
+    def attachment_add(self, filename: str, description: str | None = None) -> Path:
+        # TODO # Check to avoid slashes in file name?
+
+        attachment_path = self.attachments_dir / filename
+        self.attachments.append((attachment_path, description))
+
+        return attachment_path
+
+    # ----------------------------- Build model package info
+
+    def pkginfo(self):
+        # Generate metadata for attachments
+        att_meta = [
+            exch_attachment.meta_from_file(att_path, description=att_desc)
+            for att_path, att_desc in self.attachments
+        ]
+
+        # Create MLModelPackage object
+        return MLModelPackage(
+            metadata=MLModelMetadata(
+                name=self.slug,
+                version=self.version,
+                authors=[
+                    a for a in self.authors
+                ],  # The list generator is used to copy the list and avoid a flaky reference
+                maintainers=[
+                    m for m in self.maintainers
+                ],  # The list generator is used to copy the list and avoid a flaky reference
+                target=self.target,
+                exchange_format=self.exchange_format,
+                model_file=f"model.{self.exchange_format}",
+                attachments=att_meta,
+            ),
+            model_file_path=self.model_file,
+            example_implementation_path=self.inference_example_dir,
+            attachments_files=[att_path for att_path, _ in self.attachments],
+        )
 
 
 def _api_guard(fkt):
@@ -558,38 +654,33 @@ def model_use(ctx, slug: str):
 @_api_guard
 @contextmanager
 def model_package(
-    ctx: FlowCtx, slug: str, exchange_format: str, target: str = "agnostic"
+    ctx: FlowCtx,
+    slug: str,
+    exchange_format: str,
+    version: str | None = None,
+    target: str = "agnostic",
 ):
     # TODO # Add name argument as the display name is not the same as the slug
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Initialize package metadata
-        meta = MLModelMetadata(
-            name=slug,
-            version="TODO",  # TODO: How to treat this?
-            # TODO # How to treat the list of authors?
-            authors=[
-                MLModelAuthor(name=a.name, email=a.email, contribution=a.contribution)
-                for a in ctx.method_info.authors
-            ],
-            # TODO: How to determine list of maintainers? Maybe store as program information?
-            maintainers=[
-                MLModelMaintainer(name=a.name, email=a.email)
-                for a in ctx.method_info.authors
-            ],
-            target=target,
+        # Initialize package builder
+        builder = ModelPackageBuilder(
+            slug=slug,
+            tmpdir=tmpdir,
             exchange_format=exchange_format,
-            model_file=f"model.{exchange_format}",
+            version=version,
+            target=target,
         )
 
-        # Initialize context information
-        # TODO # Use MLModelPackage instead of this class?
-        pkginfo = ModelPackageInfo(
-            model_metadata=meta,
-            model_file_path=Path(tmpdir).resolve() / meta.model_file,
-            inference_example_path=Path(tmpdir).resolve() / "inference-example",
-        )
+        builder.folders_create()
 
-        yield pkginfo
+        # By default, add method's authors as model authors
+        # TODO Add option to remove this behaviour if needed?
+        for a in ctx.method_info.authors:
+            builder.author_add(a.name, a.email, a.contribution)
+
+        yield builder
+
+        pkginfo = builder.pkginfo()
 
         # -> Now the user should have stored files...
         # TODO: Add check that model file is effectively stored here, or else raise some exception
@@ -611,15 +702,7 @@ def model_package(
         # Now that package is created, we can create the archive
         sha256 = ctx.storage.model_store(
             slug,
-            MLModelPackage(
-                metadata=meta,
-                model_file_path=pkginfo.model_file_path,
-                example_implementation_path=(
-                    pkginfo.inference_example_path
-                    if pkginfo.inference_example_path.exists()
-                    else None
-                ),
-            ),
+            pkginfo,
         )
 
         # Add artifact metadata

--- a/src/overity/backend/flow/__init__.py
+++ b/src/overity/backend/flow/__init__.py
@@ -129,24 +129,6 @@ class LoggerWriter:
         pass
 
 
-# @dataclass
-# class ModelPackageInfo:
-#    """Metadata of the saved model"""
-#    metadata: MLModelMetadata
-#
-#    """Path to store the model file"""
-#    model_file: Path
-#
-#    """Temporary folder to save the attachments files"""
-#    attachments_dir: Path
-#
-#    """Temporary folder to save inference example"""
-#    inference_example_dir: Path
-#
-#    """List of attachment specifications"""
-#    attachments: tuple[Path, str | None]
-
-
 class ModelPackageBuilder:
     def __init__(
         self,

--- a/src/overity/errors.py
+++ b/src/overity/errors.py
@@ -193,3 +193,12 @@ class NoVersionAvailable(Exception):
 class VersioningInconsistencyError(Exception):
     def __init__(self):
         super().__init__("Cannot guarentee versioning consistency")
+
+
+class AttachmentIntegrityError(Exception):
+    def __init__(self, pp: Path, got_hash: str, expected_hash: str):
+        super().__init__(
+            "Attachment integrity error for {}: expected {}, got {}".format(
+                pp, expected_hash, got_hash
+            )
+        )

--- a/src/overity/exchange/dataset_package/package.py
+++ b/src/overity/exchange/dataset_package/package.py
@@ -13,7 +13,6 @@ Dataset packaging tools
 
 import tempfile
 import tarfile
-import hashlib
 import json
 
 from pathlib import Path
@@ -22,6 +21,7 @@ from overity.model.dataset.metadata import DatasetMetadata
 from overity.model.dataset.package import DatasetPackageInfo
 
 from overity.exchange.dataset_package import metadata as dataset_metadata
+from overity.exchange import integrity
 
 from overity.errors import MalformedDatasetPackage
 
@@ -29,16 +29,6 @@ from overity.errors import MalformedDatasetPackage
 ####################################################
 # Create package
 ####################################################
-
-
-# TODO # Merge with one used in ml model package and agent package
-def package_sha256(path: Path):
-    path = Path(path)
-
-    with open(path, "rb") as fhandle:
-        digest = hashlib.file_digest(fhandle, "sha256")
-
-    return digest
 
 
 def package_archive_create(dataset_data: DatasetPackageInfo, output_path: Path):
@@ -55,7 +45,7 @@ def package_archive_create(dataset_data: DatasetPackageInfo, output_path: Path):
             archive.add(dataset_data.dataset_data_path, arcname="data")
 
     # -> fhandle file is removed automatically when exiting the with... clause
-    return package_sha256(output_path)
+    return integrity.file_sha256(output_path)
 
 
 ####################################################

--- a/src/overity/exchange/inference_agent_package/package.py
+++ b/src/overity/exchange/inference_agent_package/package.py
@@ -13,7 +13,6 @@ Inference agent packaging tools
 
 import tempfile
 import tarfile
-import hashlib
 import json
 
 from pathlib import Path
@@ -22,6 +21,7 @@ from overity.model.inference_agent.metadata import InferenceAgentMetadata
 from overity.model.inference_agent.package import InferenceAgentPackageInfo
 
 from overity.exchange.inference_agent_package import metadata as agent_metadata
+from overity.exchange import integrity
 
 from overity.errors import MalformedAgentPackage
 
@@ -29,16 +29,6 @@ from overity.errors import MalformedAgentPackage
 ####################################################
 # Create package
 ####################################################
-
-
-# TODO # Merge with one used in ml model package
-def package_sha256(path: Path):
-    path = Path(path)
-
-    with open(path, "rb") as fhandle:
-        digest = hashlib.file_digest(fhandle, "sha256")
-
-    return digest
 
 
 def package_archive_create(agent_data: InferenceAgentPackageInfo, output_path: Path):
@@ -55,7 +45,7 @@ def package_archive_create(agent_data: InferenceAgentPackageInfo, output_path: P
             archive.add(agent_data.agent_data_path, arcname="data")
 
     # -> fhandle file is removed automatically when exiting the with... clause
-    return package_sha256(output_path)
+    return integrity.file_sha256(output_path)
 
 
 ####################################################

--- a/src/overity/exchange/integrity.py
+++ b/src/overity/exchange/integrity.py
@@ -1,0 +1,34 @@
+"""
+Integrity utilities
+===================
+
+**April 2026**
+
+- Florian Dupeyron (florian.dupeyron@mugcat.fr)
+
+> This file is part of the Overity.ai project, and is licensed under
+> the terms of the Apache 2.0 license. See the LICENSE file for more
+> information.
+"""
+
+import hashlib
+
+from pathlib import Path
+
+
+def file_sha256(pp: Path):
+    """Get the sha256 hash for a given file
+
+    Args:
+        pp: Path to input file
+
+    Returns:
+        The computed sha256 digest
+    """
+
+    path = Path(pp)
+
+    with open(path, "rb") as fhandle:
+        digest = hashlib.file_digest(fhandle, "sha256")
+
+    return digest

--- a/src/overity/exchange/model_package_v1/attachment.py
+++ b/src/overity/exchange/model_package_v1/attachment.py
@@ -1,0 +1,92 @@
+"""
+Attachment metadata encoder/decoder
+===================================
+
+**April 2026**
+
+- Florian Dupeyron (florian.dupeyron@mugcat.fr)
+
+> This file is part of the Overity.ai project, and is licensed under
+> the terms of the Apache 2.0 license. See the LICENSE file for more
+> information.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+
+from pathlib import Path
+
+from overity.model.ml_model.attachment import AttachmentMetadata
+from overity.exchange import integrity
+
+from overity.errors import AttachmentIntegrityError
+
+
+####################################################
+# Decoder
+####################################################
+
+
+def meta_decode(data: dict[str, any]) -> AttachmentMetadata:
+    # TODO Data check and sanitization, especially for hash
+
+    return AttachmentMetadata(
+        filename=data["filename"],
+        sha256_hash=data["sha256_hash"],
+        mimetype=data.get("mimetype"),
+        description=data.get("description"),
+    )
+
+
+####################################################
+# Encoder
+####################################################
+
+
+def meta_encode(attachment: AttachmentMetadata) -> dict[str, any]:
+    obj = {
+        "filename": str(attachment.filename),
+        "sha256_hash": str(attachment.sha256_hash),
+    }
+
+    if attachment.mimetype:
+        obj.update({"mimetype": attachment.mimetype})
+
+    if attachment.description:
+        obj.update({"description": attachment.description})
+
+    return obj
+
+
+####################################################
+# Metadata from file
+####################################################
+
+
+def meta_from_file(pp: Path, description: str | None = None) -> AttachmentMetadata:
+    """Generate attachment from an existing file"""
+
+    # Guess file type
+    mime_type, _ = mimetypes.guess_file_type(str(pp))
+
+    # Get file's sha256
+    digest = integrity.file_sha256(pp).hexdigest()
+
+    # Create the output AttachmentMetadata
+    return AttachmentMetadata(
+        filename=pp.name,
+        sha256_hash=digest,
+        mimetype=mime_type,
+        description=description,
+    )
+
+
+def integrity_check(pp: Path, meta: AttachmentMetadata):
+    """Check for an attachment's integrity"""
+
+    digest = integrity.file_sha256(pp)
+    hdigest = digest.hexdigest()
+
+    if hdigest != meta.sha256_hash:
+        raise AttachmentIntegrityError(pp, hdigest, meta.sha256_hash)

--- a/src/overity/exchange/model_package_v1/metadata.py
+++ b/src/overity/exchange/model_package_v1/metadata.py
@@ -22,6 +22,9 @@ from overity.model.ml_model.metadata import (
     MLModelMetadata,
 )
 
+from overity.exchange.model_package_v1 import attachment
+
+
 ####################################################
 # Decoder
 ####################################################
@@ -50,6 +53,7 @@ def _metadata_decode(data: dict[str, any]):
     target = data["target"]
     exchange_format = data["format"]
     model_file = data["model_file"]
+    attachments = [attachment.meta_decode(att) for att in data.get("attachments", [])]
     derives = data.get("derives")
 
     return MLModelMetadata(
@@ -60,6 +64,7 @@ def _metadata_decode(data: dict[str, any]):
         target=target,
         exchange_format=exchange_format,
         model_file=model_file,
+        attachments=attachments,
         derives=derives,
     )
 
@@ -120,6 +125,11 @@ def _metadata_encode(metadata: MLModelMetadata):
 
     if metadata.derives is not None:
         encode_obj["derives"] = metadata.derives
+
+    if metadata.attachments:
+        encode_obj["attachments"] = [
+            attachment.meta_encode(att) for att in metadata.attachments
+        ]
 
     return encode_obj
 

--- a/src/overity/exchange/model_package_v1/package.py
+++ b/src/overity/exchange/model_package_v1/package.py
@@ -11,6 +11,8 @@ ML Model packaging tools
 > information.
 """
 
+from __future__ import annotations
+
 import json
 import tarfile
 import tempfile
@@ -22,6 +24,7 @@ from overity.exchange import integrity
 
 from overity.model.ml_model.metadata import MLModelMetadata
 from overity.model.ml_model.package import MLModelPackage
+from overity.model.ml_model.attachment import AttachmentMetadata, ExtractedAttachment
 
 from overity.errors import MalformedModelPackage
 
@@ -93,6 +96,31 @@ def _process_model_file(
         ftarget.flush()
 
 
+def _process_attachment(
+    archive_path: Path,
+    tf: tarfile.TarFile,
+    target_folder: Path,
+    att_meta: AttachmentMetadata,
+) -> ExtractedAttachment:
+    try:
+        att_file = tf.getmember(f"attachments/{att_meta.filename}")
+    except KeyError:
+        raise MalformedModelPackage(
+            archive_path, f"Attachment '{att_meta.filename}' not found in archive file"
+        )
+
+    target_path = target_folder / att_meta.filename
+
+    with open(target_path, "wb") as ftarget, tf.extractfile(att_file) as fatt:
+        ftarget.write(fatt.read())
+        ftarget.flush()
+
+    return ExtractedAttachment(
+        meta=att_meta,
+        path=target_path,
+    )
+
+
 def metadata_load(archive_path: Path) -> MLModelMetadata:
     """Load only metadata from archive path"""
 
@@ -104,13 +132,30 @@ def metadata_load(archive_path: Path) -> MLModelMetadata:
     return meta
 
 
-def model_load(archive_path: Path, target_folder: Path) -> MLModelMetadata:
+def model_load(
+    archive_path: Path, target_folder: Path
+) -> tuple[MLModelMetadata, dict[str, ExtractedAttachment]]:
     """Load model metadata from archive, and load model implementation in ftarget"""
 
     archive_path = Path(archive_path)
+    target_folder = Path(target_folder)
+
+    attachments_folder = target_folder / "attachments"
 
     with tarfile.open(archive_path, "r:gz") as archive:
         meta = _process_metadata(archive_path, archive)
         _process_model_file(archive_path, archive, meta, target_folder)
 
-    return meta
+        attachments = {}
+
+        # Process attachments if any
+        if meta.attachments:
+            attachments_folder.mkdir(parents=True)
+            attachments = {
+                att.filename: _process_attachment(
+                    archive_path, archive, attachments_folder, att
+                )
+                for att in meta.attachments
+            }
+
+    return meta, attachments

--- a/src/overity/exchange/model_package_v1/package.py
+++ b/src/overity/exchange/model_package_v1/package.py
@@ -14,26 +14,16 @@ ML Model packaging tools
 import json
 import tarfile
 import tempfile
-import hashlib
 
 from pathlib import Path
 
 from overity.exchange.model_package_v1 import metadata as ml_metadata
+from overity.exchange import integrity
 
 from overity.model.ml_model.metadata import MLModelMetadata
 from overity.model.ml_model.package import MLModelPackage
 
 from overity.errors import MalformedModelPackage
-
-
-# TODO # Merge with one used in inference agent package
-def package_sha256(path: Path):
-    path = Path(path)
-
-    with open(path, "rb") as fhandle:
-        digest = hashlib.file_digest(fhandle, "sha256")
-
-    return digest
 
 
 def package_archive_create(model_data: MLModelPackage, output_path: Path):
@@ -46,16 +36,24 @@ def package_archive_create(model_data: MLModelPackage, output_path: Path):
 
         # Create output archive
         with tarfile.open(output_path, "w:gz") as archive:
+            # Add model metadata
             archive.add(fhandle.name, arcname="model-metadata.json")
+
+            # Add model file
             archive.add(
                 model_data.model_file_path, arcname=model_data.metadata.model_file
             )
 
+            # Add attachments
+            for att in model_data.attachments_files:
+                archive.add(str(att), arcname=f"attachments/{att.name}")
+
+            # Add inference example folder
             if model_data.example_implementation_path is not None:
                 archive.add(model_data.example_implementation_path, "inference-example")
 
     # -> fhandle file is removed automatically when exiting the with... clause
-    return package_sha256(output_path)
+    return integrity.file_sha256(output_path)
 
 
 def _process_metadata(archive_path: Path, tf: tarfile.TarFile):

--- a/src/overity/model/ml_model/attachment.py
+++ b/src/overity/model/ml_model/attachment.py
@@ -1,0 +1,45 @@
+"""
+Model attachment model
+======================
+
+**April 2026**
+
+- Florian Dupeyron (florian.dupeyron@mugcat.fr)
+
+> This file is part of the Overity.ai project, and is licensed under
+> the terms of the Apache 2.0 license. See the LICENSE file for more
+> information.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class AttachmentMetadata:
+    """Defines the metadata for an attachment"""
+
+    """Name of the attachment in model archive"""
+    filename: str
+
+    """sha256 hash"""
+    sha256_hash: str
+
+    """MIME Type indication"""
+    mimetype: str | None = None
+
+    """Optional description"""
+    description: str | None = None
+
+
+@dataclass
+class ExtractedAttachment:
+    """Represents an extracted attachment. Useful for API"""
+
+    """Metadata of the extracted attachment"""
+    meta: AttachmentMetadata
+
+    """Path of local extracted file"""
+    path: Path

--- a/src/overity/model/ml_model/metadata.py
+++ b/src/overity/model/ml_model/metadata.py
@@ -11,8 +11,10 @@ ML Model metadata model
 > information.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
+
+from overity.model.ml_model.attachment import AttachmentMetadata
 
 
 @dataclass
@@ -70,6 +72,9 @@ class MLModelMetadata:
 
     """Relative to input model file in the package archive file"""
     model_file: str
+
+    """List of attachments available in the model archive"""
+    attachments: List[AttachmentMetadata] = field(default_factory=list)
 
     """Optional identification string indicating which model this model derives from"""
     derives: Optional[str] = None

--- a/src/overity/model/ml_model/package.py
+++ b/src/overity/model/ml_model/package.py
@@ -11,9 +11,10 @@ Model definition for ML model packages
 > information.
 """
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 from overity.model.ml_model.metadata import MLModelMetadata
 
@@ -28,5 +29,8 @@ class MLModelPackage:
     """Path to input model file on local disk"""
     model_file_path: Path
 
+    """Additional attachments information"""
+    attachments_files: list[Path] = field(default_factory=list)
+
     """Path to example implementation folder on local disk"""
-    example_implementation_path: Optional[Path] = None
+    example_implementation_path: Path | None = None

--- a/src/overity/storage/base.py
+++ b/src/overity/storage/base.py
@@ -11,6 +11,8 @@ Storage backend base class
 > information.
 """
 
+from __future__ import annotations
+
 import re
 import uuid
 from abc import ABC, abstractmethod
@@ -20,6 +22,8 @@ from typing import Callable
 from overity.model.general_info.method import MethodKind
 from overity.model.ml_model.metadata import MLModelMetadata
 from overity.model.ml_model.package import MLModelPackage
+from overity.model.ml_model.attachment import ExtractedAttachment
+
 from overity.model.report import MethodReportKind
 
 from overity.model.inference_agent.metadata import InferenceAgentMetadata
@@ -215,8 +219,8 @@ class StorageBackend(ABC):
     @abstractmethod
     def model_load(
         self, slug: str, target_folder: Path
-    ) -> tuple[MLModelMetadata, HashObject]:
-        """Load a model package. Returns (metadata, sha256_hash)"""
+    ) -> tuple[MLModelMetadata, HashObject, dict[str, ExtractedAttachment]]:
+        """Load a model package. Returns (metadata, sha256_hash, attachments)"""
 
     @abstractmethod
     def model_store(self, slug: str, package: MLModelPackage):

--- a/src/overity/storage/local/__init__.py
+++ b/src/overity/storage/local/__init__.py
@@ -25,6 +25,7 @@ from overity.model.general_info.bench import (
 )
 from overity.model.ml_model.metadata import MLModelMetadata
 from overity.model.ml_model.package import MLModelPackage
+from overity.model.ml_model.attachment import ExtractedAttachment
 from overity.model.report import MethodReportKind, MethodExecutionStatus
 
 from overity.model.inference_agent.metadata import InferenceAgentMetadata
@@ -859,18 +860,18 @@ class LocalStorage(StorageBackend):
 
     def model_load(
         self, slug: str, target_folder: Path
-    ) -> tuple[MLModelMetadata, HashObject]:
+    ) -> tuple[MLModelMetadata, HashObject, dict[str, ExtractedAttachment]]:
         fpath = self._model_path(slug)
 
         if not fpath.is_file():
             raise ModelNotFound(slug)
 
-        pkginfo = ml_package.model_load(fpath, target_folder)
+        pkginfo, attachments = ml_package.model_load(fpath, target_folder)
 
         # Compute SHA256 of the archive file
         sha256 = integrity.file_sha256(fpath)
 
-        return pkginfo, sha256
+        return pkginfo, sha256, attachments
 
     def model_store(self, slug: str, pkg: MLModelPackage):
         fpath = self._model_path(slug)  # Get path for target archive

--- a/src/overity/storage/local/__init__.py
+++ b/src/overity/storage/local/__init__.py
@@ -66,6 +66,7 @@ from overity.errors import (
 from overity.exchange.model_package_v1 import package as ml_package
 from overity.exchange.inference_agent_package import package as agent_package
 from overity.exchange.dataset_package import package as dataset_package
+from overity.exchange import integrity
 
 
 log = logging.getLogger("Local storage")
@@ -867,7 +868,7 @@ class LocalStorage(StorageBackend):
         pkginfo = ml_package.model_load(fpath, target_folder)
 
         # Compute SHA256 of the archive file
-        sha256 = ml_package.package_sha256(fpath)
+        sha256 = integrity.file_sha256(fpath)
 
         return pkginfo, sha256
 
@@ -902,7 +903,7 @@ class LocalStorage(StorageBackend):
         pkginfo = agent_package.agent_load(fpath, target_folder)
 
         # Compute SHA256 of the archive file
-        sha256 = agent_package.package_sha256(fpath)
+        sha256 = integrity.file_sha256(fpath)
 
         return pkginfo, sha256
 
@@ -937,7 +938,7 @@ class LocalStorage(StorageBackend):
         pkginfo = dataset_package.dataset_load(fpath, target_folder)
 
         # Compute SHA256 of the archive file
-        sha256 = dataset_package.package_sha256(fpath)
+        sha256 = integrity.file_sha256(fpath)
 
         return pkginfo, sha256
 

--- a/tests/test_exchange_dataset_package_package.py
+++ b/tests/test_exchange_dataset_package_package.py
@@ -8,11 +8,11 @@ import tarfile
 import json
 from pathlib import Path
 from overity.exchange.dataset_package.package import (
-    package_sha256,
     package_archive_create,
     metadata_load,
     dataset_load,
 )
+from overity.exchange import integrity
 from overity.model.dataset.metadata import (
     DatasetMetadata,
     DatasetAuthor,
@@ -23,7 +23,7 @@ from overity.errors import MalformedDatasetPackage
 
 
 class TestDatasetPackagePackage:
-    def test_package_sha256(self):
+    def test_file_sha256(self):
         """Test computing SHA256 hash of a file."""
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(b"test content")
@@ -31,7 +31,7 @@ class TestDatasetPackagePackage:
             path = Path(f.name)
 
         try:
-            result = package_sha256(path).hexdigest()
+            result = integrity.file_sha256(path).hexdigest()
             # Known SHA256 hash of "test content"
             assert (
                 result

--- a/tests/test_exchange_inference_agent_package_package.py
+++ b/tests/test_exchange_inference_agent_package_package.py
@@ -8,11 +8,11 @@ import tarfile
 import json
 from pathlib import Path
 from overity.exchange.inference_agent_package.package import (
-    package_sha256,
     package_archive_create,
     metadata_load,
     agent_load,
 )
+from overity.exchange import integrity
 from overity.model.inference_agent.metadata import (
     InferenceAgentMetadata,
     InferenceAgentAuthor,
@@ -23,7 +23,7 @@ from overity.errors import MalformedAgentPackage
 
 
 class TestInferenceAgentPackagePackage:
-    def test_package_sha256(self):
+    def test_file_sha256(self):
         """Test computing SHA256 hash of a file."""
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(b"test content")
@@ -31,7 +31,7 @@ class TestInferenceAgentPackagePackage:
             path = Path(f.name)
 
         try:
-            result = package_sha256(path).hexdigest()
+            result = integrity.file_sha256(path).hexdigest()
             # Known SHA256 hash of "test content"
             assert (
                 result

--- a/tests/test_exchange_integrity.py
+++ b/tests/test_exchange_integrity.py
@@ -1,0 +1,273 @@
+"""Unit tests for the overity.exchange.integrity module."""
+
+import hashlib
+import tempfile
+from pathlib import Path
+import pytest
+from unittest.mock import patch, mock_open
+
+from overity.exchange.integrity import file_sha256
+
+
+class TestFileSHA256:
+    """Test cases for the file_sha256 function."""
+    
+    def test_file_sha256_with_known_content(self):
+        """Test SHA256 computation with known content."""
+        # Create a temporary file with known content
+        test_content = b"Hello, World!"
+        expected_hash = hashlib.sha256(test_content).hexdigest()
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_content)
+            temp_file_path = Path(temp_file.name)
+        
+        try:
+            # Compute hash using our function
+            result = file_sha256(temp_file_path)
+            assert result.hexdigest() == expected_hash
+        finally:
+            # Clean up
+            temp_file_path.unlink()
+    
+    def test_file_sha256_empty_file(self):
+        """Test SHA256 computation with empty file."""
+        # Expected hash for empty content
+        expected_hash = hashlib.sha256(b"").hexdigest()
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file_path = Path(temp_file.name)
+        
+        try:
+            result = file_sha256(temp_file_path)
+            assert result.hexdigest() == expected_hash
+        finally:
+            temp_file_path.unlink()
+    
+    def test_file_sha256_large_file(self):
+        """Test SHA256 computation with larger content."""
+        # Create content that's larger than typical buffer sizes
+        test_content = b"A" * 1024 * 1024  # 1MB of 'A's
+        expected_hash = hashlib.sha256(test_content).hexdigest()
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_content)
+            temp_file_path = Path(temp_file.name)
+        
+        try:
+            result = file_sha256(temp_file_path)
+            assert result.hexdigest() == expected_hash
+        finally:
+            temp_file_path.unlink()
+    
+    def test_file_sha256_binary_content(self):
+        """Test SHA256 computation with binary content."""
+        # Create binary content with various byte values
+        test_content = bytes(range(256))  # All possible byte values 0-255
+        expected_hash = hashlib.sha256(test_content).hexdigest()
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_content)
+            temp_file_path = Path(temp_file.name)
+        
+        try:
+            result = file_sha256(temp_file_path)
+            assert result.hexdigest() == expected_hash
+        finally:
+            temp_file_path.unlink()
+    
+    def test_file_sha256_nonexistent_file(self):
+        """Test error handling for non-existent file."""
+        nonexistent_path = Path("/tmp/nonexistent_file_12345.txt")
+        
+        with pytest.raises(FileNotFoundError):
+            file_sha256(nonexistent_path)
+    
+    def test_file_sha256_directory_path(self):
+        """Test error handling when given a directory path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dir_path = Path(temp_dir)
+            
+            with pytest.raises(IsADirectoryError):
+                file_sha256(dir_path)
+    
+    def test_file_sha256_string_path(self):
+        """Test that function accepts string paths in addition to Path objects."""
+        test_content = b"Test content for string path"
+        expected_hash = hashlib.sha256(test_content).hexdigest()
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_content)
+            temp_file_path = temp_file.name  # String path
+        
+        try:
+            result = file_sha256(temp_file_path)
+            assert result.hexdigest() == expected_hash
+        finally:
+            Path(temp_file_path).unlink()
+    
+    def test_file_sha256_result_has_hexdigest_method(self):
+        """Test that the returned object has the expected hexdigest method."""
+        test_content = b"Test content"
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_content)
+            temp_file_path = Path(temp_file.name)
+        
+        try:
+            result = file_sha256(temp_file_path)
+            # Should have hexdigest method
+            assert hasattr(result, 'hexdigest')
+            # Should return a string
+            hex_digest = result.hexdigest()
+            assert isinstance(hex_digest, str)
+            # Should be 64 characters (256 bits = 64 hex chars)
+            assert len(hex_digest) == 64
+            # Should be lowercase hex
+            assert hex_digest.islower()
+            # Should only contain hex characters
+            assert all(c in '0123456789abcdef' for c in hex_digest)
+        finally:
+            temp_file_path.unlink()
+    
+    def test_file_sha256_consistency(self):
+        """Test that the same file produces the same hash consistently."""
+        test_content = b"Consistent content test"
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_content)
+            temp_file_path = Path(temp_file.name)
+        
+        try:
+            # Compute hash multiple times
+            hash1 = file_sha256(temp_file_path).hexdigest()
+            hash2 = file_sha256(temp_file_path).hexdigest()
+            hash3 = file_sha256(temp_file_path).hexdigest()
+            
+            # All should be identical
+            assert hash1 == hash2 == hash3
+        finally:
+            temp_file_path.unlink()
+    
+    def test_file_sha256_different_files_different_hashes(self):
+        """Test that different files produce different hashes."""
+        content1 = b"Content number one"
+        content2 = b"Content number two"
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file1:
+            temp_file1.write(content1)
+            temp_file1_path = Path(temp_file1.name)
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file2:
+            temp_file2.write(content2)
+            temp_file2_path = Path(temp_file2.name)
+        
+        try:
+            hash1 = file_sha256(temp_file1_path).hexdigest()
+            hash2 = file_sha256(temp_file2_path).hexdigest()
+            
+            # Different content should produce different hashes
+            assert hash1 != hash2
+        finally:
+            temp_file1_path.unlink()
+            temp_file2_path.unlink()
+    
+    def test_file_sha256_permission_error(self):
+        """Test handling of permission errors."""
+        test_content = b"Permission test content"
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(test_content)
+            temp_file_path = Path(temp_file.name)
+        
+        try:
+            # Mock the open function to raise PermissionError
+            with patch('builtins.open', side_effect=PermissionError("Permission denied")):
+                with pytest.raises(PermissionError):
+                    file_sha256(temp_file_path)
+        finally:
+            temp_file_path.unlink()
+    
+    def test_file_sha256_unicode_content(self):
+        """Test SHA256 computation with unicode content."""
+        # UTF-8 encoded unicode content
+        unicode_text = "Hello 世界! 🌍 Ñoël"
+        test_content = unicode_text.encode('utf-8')
+        expected_hash = hashlib.sha256(test_content).hexdigest()
+        
+        with tempfile.NamedTemporaryFile(delete=False, mode='w', encoding='utf-8') as temp_file:
+            temp_file.write(unicode_text)
+            temp_file_path = Path(temp_file.name)
+        
+        try:
+            result = file_sha256(temp_file_path)
+            assert result.hexdigest() == expected_hash
+        finally:
+            temp_file_path.unlink()
+    
+    def test_file_sha256_special_chars_in_filename(self):
+        """Test with filenames containing special characters."""
+        test_content = b"Special filename test content"
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create file with special characters in name
+            special_filename = "test_file-with_special.chars!@#$%.txt"
+            file_path = Path(temp_dir) / special_filename
+            
+            file_path.write_bytes(test_content)
+            
+            expected_hash = hashlib.sha256(test_content).hexdigest()
+            result = file_sha256(file_path)
+            assert result.hexdigest() == expected_hash
+
+
+class TestFileSHA256Integration:
+    """Integration tests for file_sha256 with package-related scenarios."""
+    
+    def test_file_sha256_package_like_scenario(self):
+        """Test hash computation in a scenario similar to package creation."""
+        # Simulate content that might be in a package
+        package_content = {
+            'model.json': b'{"name": "test_model", "version": "1.0"}',
+            'weights.bin': b'\x00\x01\x02\x03' * 1000,  # Binary weights
+            'metadata.yaml': b'name: test_model\nversion: 1.0\nframework: pytorch\n',
+        }
+        
+        computed_hashes = {}
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            
+            # Create files and compute hashes
+            for filename, content in package_content.items():
+                file_path = temp_path / filename
+                file_path.write_bytes(content)
+                
+                # Compute hash using our function
+                result = file_sha256(file_path)
+                computed_hashes[filename] = result.hexdigest()
+                
+                # Verify against expected hash
+                expected_hash = hashlib.sha256(content).hexdigest()
+                assert computed_hashes[filename] == expected_hash
+        
+        # Verify all hashes are different (different content)
+        hash_values = list(computed_hashes.values())
+        assert len(set(hash_values)) == len(hash_values), "All files should have unique hashes"
+    
+    def test_file_sha256_large_binary_file(self):
+        """Test with a large binary file similar to model weights."""
+        # Create 5MB of pseudo-random binary data
+        import os
+        large_content = os.urandom(5 * 1024 * 1024)
+        expected_hash = hashlib.sha256(large_content).hexdigest()
+        
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(large_content)
+            temp_file_path = Path(temp_file.name)
+        
+        try:
+            result = file_sha256(temp_file_path)
+            assert result.hexdigest() == expected_hash
+        finally:
+            temp_file_path.unlink()

--- a/tests/test_exchange_model_package_v1_attachment.py
+++ b/tests/test_exchange_model_package_v1_attachment.py
@@ -5,6 +5,7 @@ Unit tests for model_package_v1/attachment.py
 import pytest
 import tempfile
 import json
+import tarfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 from overity.exchange.model_package_v1.attachment import (
@@ -13,7 +14,7 @@ from overity.exchange.model_package_v1.attachment import (
     meta_from_file,
     integrity_check,
 )
-from overity.model.ml_model.attachment import AttachmentMetadata
+from overity.model.ml_model.attachment import AttachmentMetadata, ExtractedAttachment
 from overity.errors import AttachmentIntegrityError
 
 
@@ -499,3 +500,93 @@ class TestAttachmentRoundTrip:
         }
         assert "mimetype" not in encoded
         assert "description" not in encoded
+
+    def test_process_attachment_missing_file(self):
+        """Test _process_attachment when attachment file is missing from archive."""
+        from overity.exchange.model_package_v1.package import _process_attachment
+        from overity.errors import MalformedModelPackage
+        
+        # Create a fake tarfile with no attachment
+        with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+            archive_path = Path(f.name)
+        
+        # Create empty archive
+        with tarfile.open(archive_path, "w:gz") as archive:
+            pass  # Empty archive
+        
+        # Create target folder
+        with tempfile.TemporaryDirectory() as target_dir:
+            target_path = Path(target_dir)
+            
+            # Create attachment metadata
+            att_meta = AttachmentMetadata(
+                filename="missing.txt",
+                sha256_hash="abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
+                mimetype="text/plain"
+            )
+            
+            try:
+                # Open archive for reading
+                with tarfile.open(archive_path, "r:gz") as archive:
+                    # Should raise MalformedModelPackage
+                    with pytest.raises(MalformedModelPackage) as exc_info:
+                        _process_attachment(archive_path, archive, target_path, att_meta)
+                    
+                    # Verify error message
+                    assert "missing.txt" in str(exc_info.value)
+                    assert "not found in archive" in str(exc_info.value)
+            finally:
+                archive_path.unlink()
+
+    def test_process_attachment_success(self):
+        """Test _process_attachment when attachment file exists in archive."""
+        from overity.exchange.model_package_v1.package import _process_attachment
+        
+        # Create attachment content
+        att_content = b"This is attachment content for testing"
+        
+        # Create temporary file with attachment content
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(att_content)
+            att_file_path = Path(f.name)
+        
+        # Create archive with attachment
+        with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+            archive_path = Path(f.name)
+        
+        with tarfile.open(archive_path, "w:gz") as archive:
+            archive.add(str(att_file_path), arcname="attachments/test_file.txt")
+        
+        # Create target folder
+        with tempfile.TemporaryDirectory() as target_dir:
+            target_path = Path(target_dir)
+            
+            # Create attachment metadata
+            att_meta = AttachmentMetadata(
+                filename="test_file.txt",
+                sha256_hash="dummy_hash",
+                mimetype="text/plain",
+                description="Test attachment"
+            )
+            
+            try:
+                # Open archive for reading
+                with tarfile.open(archive_path, "r:gz") as archive:
+                    # Process attachment
+                    result = _process_attachment(archive_path, archive, target_path, att_meta)
+                    
+                    # Verify result
+                    assert isinstance(result, ExtractedAttachment)
+                    assert result.meta.filename == "test_file.txt"
+                    assert result.meta.mimetype == "text/plain"
+                    assert result.meta.description == "Test attachment"
+                    assert result.path.exists()
+                    assert result.path.read_bytes() == att_content
+                    
+                    # Verify file was extracted to correct location
+                    expected_path = target_path / "test_file.txt"
+                    assert result.path == expected_path
+                    assert expected_path.exists()
+            finally:
+                archive_path.unlink()
+                att_file_path.unlink()

--- a/tests/test_exchange_model_package_v1_attachment.py
+++ b/tests/test_exchange_model_package_v1_attachment.py
@@ -1,0 +1,501 @@
+"""
+Unit tests for model_package_v1/attachment.py
+"""
+
+import pytest
+import tempfile
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from overity.exchange.model_package_v1.attachment import (
+    meta_decode,
+    meta_encode,
+    meta_from_file,
+    integrity_check,
+)
+from overity.model.ml_model.attachment import AttachmentMetadata
+from overity.errors import AttachmentIntegrityError
+
+
+class TestAttachmentDecode:
+    """Test the meta_decode function"""
+
+    def test_valid_meta_decode(self):
+        """Test decoding valid attachment data"""
+        data = {
+            "filename": "test_file.pdf",
+            "sha256_hash": "abc123def456",
+            "mimetype": "application/pdf",
+            "description": "Test PDF file"
+        }
+        
+        result =             meta_decode(data)
+        
+        assert isinstance(result, AttachmentMetadata)
+        assert result.filename == "test_file.pdf"
+        assert result.sha256_hash == "abc123def456"
+        assert result.mimetype == "application/pdf"
+        assert result.description == "Test PDF file"
+
+    def test_valid_meta_decode_without_description(self):
+        """Test decoding valid attachment data without description"""
+        data = {
+            "filename": "test_file.txt",
+            "sha256_hash": "def456abc123",
+            "mimetype": "text/plain"
+        }
+        
+        result =             meta_decode(data)
+        
+        assert isinstance(result, AttachmentMetadata)
+        assert result.filename == "test_file.txt"
+        assert result.sha256_hash == "def456abc123"
+        assert result.mimetype == "text/plain"
+        assert result.description is None
+
+    def test_meta_decode_missing_required_field(self):
+        """Test decoding attachment data missing required fields"""
+        data = {
+            "filename": "test_file.txt",
+            # Missing sha256_hash
+            "mimetype": "text/plain"
+        }
+        
+        with pytest.raises(KeyError):
+            meta_decode(data)
+
+    def test_meta_decode_empty_data(self):
+        """Test decoding empty attachment data"""
+        data = {}
+        
+        with pytest.raises(KeyError):
+            meta_decode(data)
+
+
+class TestAttachmentEncode:
+    """Test the meta_encode function"""
+
+    def test_valid_meta_encode_with_description(self):
+        """Test encoding attachment metadata with description"""
+        attachment = AttachmentMetadata(
+            filename="test_file.pdf",
+            sha256_hash="abc123def456",
+            mimetype="application/pdf",
+            description="Test PDF file"
+        )
+        
+        result = meta_encode(attachment)
+        
+        assert result == {
+            "filename": "test_file.pdf",
+            "sha256_hash": "abc123def456",
+            "mimetype": "application/pdf",
+            "description": "Test PDF file"
+        }
+
+    def test_valid_meta_encode_without_description(self):
+        """Test encoding attachment metadata without description"""
+        attachment = AttachmentMetadata(
+            filename="test_file.txt",
+            sha256_hash="def456abc123",
+            mimetype="text/plain"
+        )
+        
+        result = meta_encode(attachment)
+        
+        assert result == {
+            "filename": "test_file.txt",
+            "sha256_hash": "def456abc123",
+            "mimetype": "text/plain"
+        }
+
+    def test_meta_encode_with_empty_description(self):
+        """Test encoding attachment metadata with empty description"""
+        attachment = AttachmentMetadata(
+            filename="test_file.txt",
+            sha256_hash="def456abc123",
+            mimetype="text/plain",
+            description=""
+        )
+        
+        result = meta_encode(attachment)
+        
+        assert result == {
+            "filename": "test_file.txt",
+            "sha256_hash": "def456abc123",
+            "mimetype": "text/plain"
+        }
+
+
+class TestAttachmentMetaFromFile:
+    """Test the meta_from_file function"""
+
+    def test_attachment_meta_from_text_file(self):
+        """Test creating attachment metadata from a text file"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write("This is test content for attachment")
+            f.flush()
+            file_path = Path(f.name)
+        
+        try:
+            result = meta_from_file(file_path, description="Test text file")
+            
+            assert isinstance(result, AttachmentMetadata)
+            assert result.filename == file_path.name
+            assert result.mimetype == "text/plain"
+            assert result.description == "Test text file"
+            assert len(result.sha256_hash) == 64  # SHA256 hex digest length
+            
+            # Verify the hash is a valid hex string (64 characters for SHA256)
+            assert len(result.sha256_hash) == 64
+            assert all(c in '0123456789abcdef' for c in result.sha256_hash)
+            
+        finally:
+            file_path.unlink()
+
+    def test_attachment_meta_from_pdf_file(self):
+        """Test creating attachment metadata from a PDF file"""
+        with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as f:
+            f.write(b"%PDF-1.4 fake pdf content")
+            f.flush()
+            file_path = Path(f.name)
+        
+        try:
+            result = meta_from_file(file_path)
+            
+            assert isinstance(result, AttachmentMetadata)
+            assert result.filename == file_path.name
+            assert result.mimetype == "application/pdf"
+            assert result.description is None
+            assert len(result.sha256_hash) == 64
+            
+        finally:
+            file_path.unlink()
+
+    def test_attachment_meta_from_unknown_file_type(self):
+        """Test creating attachment metadata from a file with unknown extension"""
+        with tempfile.NamedTemporaryFile(suffix='.unknown', delete=False) as f:
+            f.write(b"some unknown file content")
+            f.flush()
+            file_path = Path(f.name)
+        
+        try:
+            result = meta_from_file(file_path, description="Unknown file")
+            
+            assert isinstance(result, AttachmentMetadata)
+            assert result.filename == file_path.name
+            assert result.mimetype is None  # Unknown file types return None
+            assert result.description == "Unknown file"
+            assert len(result.sha256_hash) == 64
+            
+        finally:
+            file_path.unlink()
+
+    def test_attachment_meta_from_binary_file(self):
+        """Test creating attachment metadata from a binary file"""
+        with tempfile.NamedTemporaryFile(suffix='.jpg', delete=False) as f:
+            f.write(b'\xff\xd8\xff\xe0\x00\x10JFIF')  # JPEG header
+            f.write(b'more fake image data')
+            f.flush()
+            file_path = Path(f.name)
+        
+        try:
+            result = meta_from_file(file_path)
+            
+            assert isinstance(result, AttachmentMetadata)
+            assert result.filename == file_path.name
+            assert result.mimetype == "image/jpeg"
+            assert result.description is None
+            assert len(result.sha256_hash) == 64
+            
+        finally:
+            file_path.unlink()
+
+    def test_attachment_meta_from_nonexistent_file(self):
+        """Test creating attachment metadata from a non-existent file"""
+        nonexistent_path = Path("/path/that/does/not/exist.txt")
+        
+        with pytest.raises(FileNotFoundError):
+            meta_from_file(nonexistent_path)
+
+    @patch('overity.exchange.model_package_v1.attachment.integrity.file_sha256')
+    def test_meta_from_file_integrity_error(self, mock_file_sha256):
+        """Test handling of integrity.file_sha256 errors"""
+        mock_file_sha256.side_effect = Exception("Integrity error")
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write("test content")
+            f.flush()
+            file_path = Path(f.name)
+        
+        try:
+            with pytest.raises(Exception):
+                meta_from_file(file_path)
+        finally:
+            file_path.unlink()
+
+
+class TestAttachmentIntegrityCheck:
+    """Test the integrity_check function"""
+
+    def test_valid_integrity_check(self):
+        """Test successful attachment integrity check"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write("Test content for integrity check")
+            f.flush()
+            file_path = Path(f.name)
+        
+        try:
+            # Create metadata with correct hash
+            import hashlib
+            with open(file_path, 'rb') as file:
+                digest = hashlib.file_digest(file, 'sha256')
+                correct_hash = digest.hexdigest()
+            
+            meta = AttachmentMetadata(
+                filename="test_file",
+                sha256_hash=correct_hash,
+                mimetype="text/plain"
+            )
+            
+            # Should not raise any exception
+            integrity_check(file_path, meta)
+            
+        finally:
+            file_path.unlink()
+
+    def test_invalid_integrity_check(self):
+        """Test attachment integrity check with invalid hash"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write("Test content for integrity check")
+            f.flush()
+            file_path = Path(f.name)
+        
+        try:
+            # Create metadata with incorrect hash
+            meta = AttachmentMetadata(
+                filename="test_file",
+                sha256_hash="incorrect_hash_value_123456789012345678901234567890123456789012345678901234567890",
+                mimetype="text/plain"
+            )
+            
+            with pytest.raises(AttachmentIntegrityError) as exc_info:
+                integrity_check(file_path, meta)
+            
+            # Verify the error message contains expected information
+            error_msg = str(exc_info.value)
+            assert "Attachment integrity error" in error_msg
+            assert str(file_path) in error_msg
+            assert "incorrect_hash_value" in error_msg
+            
+        finally:
+            file_path.unlink()
+
+    def test_integrity_check_nonexistent_file(self):
+        """Test attachment integrity check with non-existent file"""
+        nonexistent_path = Path("/path/that/does/not/exist.txt")
+        
+        meta = AttachmentMetadata(
+            filename="test_file",
+            sha256_hash="some_hash_value",
+            mimetype="text/plain"
+        )
+        
+        with pytest.raises(FileNotFoundError):
+                integrity_check(nonexistent_path, meta)
+
+    @patch('overity.exchange.model_package_v1.attachment.integrity.file_sha256')
+    def test_integrity_check_integrity_error(self, mock_file_sha256):
+        """Test handling of integrity.file_sha256 errors during integrity check"""
+        mock_file_sha256.side_effect = Exception("Integrity error")
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write("test content")
+            f.flush()
+            file_path = Path(f.name)
+        
+        meta = AttachmentMetadata(
+            filename="test_file",
+            sha256_hash="some_hash_value",
+            mimetype="text/plain"
+        )
+        
+        try:
+            with pytest.raises(Exception):
+                integrity_check(file_path, meta)
+        finally:
+            file_path.unlink()
+
+
+class TestAttachmentRoundTrip:
+    """Test encoding and decoding round trips"""
+
+    def test_attachment_round_trip_with_description(self):
+        """Test encoding then decoding attachment metadata with description"""
+        original = AttachmentMetadata(
+            filename="test_document.pdf",
+            sha256_hash="abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            mimetype="application/pdf",
+            description="Important test document"
+        )
+        
+        # Encode then decode
+        encoded = meta_encode(original)
+        decoded = meta_decode(encoded)
+        
+        # Verify round trip preserves all data
+        assert decoded.filename == original.filename
+        assert decoded.sha256_hash == original.sha256_hash
+        assert decoded.mimetype == original.mimetype
+        assert decoded.description == original.description
+
+    def test_attachment_round_trip_without_description(self):
+        """Test encoding then decoding attachment metadata without description."""
+        original = AttachmentMetadata(
+            filename="simple_file.txt",
+            sha256_hash="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            mimetype="text/plain"
+        )
+        
+        # Encode then decode
+        encoded = meta_encode(original)
+        decoded = meta_decode(encoded)
+        
+        # Verify round trip preserves all data
+        assert decoded.filename == original.filename
+        assert decoded.sha256_hash == original.sha256_hash
+        assert decoded.mimetype == original.mimetype
+        assert decoded.description is None
+
+    def test_meta_encode_with_none_mimetype(self):
+        """Test encoding attachment metadata with mimetype=None."""
+        attachment = AttachmentMetadata(
+            filename="unknown_file.xyz",
+            sha256_hash="abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
+            mimetype=None
+        )
+        
+        result = meta_encode(attachment)
+        
+        # Should not include mimetype field when it's None
+        assert result == {
+            "filename": "unknown_file.xyz",
+            "sha256_hash": "abc123def4567890abc123def4567890abc123def4567890abc123def4567890"
+        }
+        assert "mimetype" not in result
+
+    def test_meta_encode_with_none_mimetype_and_description(self):
+        """Test encoding attachment metadata with both mimetype=None and no description."""
+        attachment = AttachmentMetadata(
+            filename="minimal_file.bin",
+            sha256_hash="def456abc1237890def456abc1237890def456abc1237890def456abc1237890",
+            mimetype=None,
+            description=None
+        )
+        
+        result = meta_encode(attachment)
+        
+        # Should only include required fields
+        assert result == {
+            "filename": "minimal_file.bin",
+            "sha256_hash": "def456abc1237890def456abc1237890def456abc1237890def456abc1237890"
+        }
+        assert "mimetype" not in result
+        assert "description" not in result
+
+    def test_meta_decode_without_mimetype_field(self):
+        """Test decoding attachment data when mimetype field is missing."""
+        data = {
+            "filename": "file_without_mimetype.txt",
+            "sha256_hash": "abc123def4567890abc123def4567890abc123def4567890abc123def4567890"
+        }
+        
+        result = meta_decode(data)
+        
+        assert isinstance(result, AttachmentMetadata)
+        assert result.filename == "file_without_mimetype.txt"
+        assert result.sha256_hash == "abc123def4567890abc123def4567890abc123def4567890abc123def4567890"
+        assert result.mimetype is None
+        assert result.description is None
+
+    def test_meta_decode_with_mimetype_none(self):
+        """Test decoding attachment data when mimetype is explicitly None."""
+        data = {
+            "filename": "file_with_none_mimetype.txt",
+            "sha256_hash": "def456abc1237890def456abc1237890def456abc1237890def456abc1237890",
+            "mimetype": None
+        }
+        
+        result = meta_decode(data)
+        
+        assert isinstance(result, AttachmentMetadata)
+        assert result.filename == "file_with_none_mimetype.txt"
+        assert result.sha256_hash == "def456abc1237890def456abc1237890def456abc1237890def456abc1237890"
+        assert result.mimetype is None
+        assert result.description is None
+
+    def test_meta_decode_with_missing_mimetype_but_with_description(self):
+        """Test decoding attachment data when mimetype is missing but description is present."""
+        data = {
+            "filename": "file_with_description_only.md",
+            "sha256_hash": "xyz789uvw456abc123def4567890abc123def4567890abc123def4567890abc",
+            "description": "File with description but no mimetype"
+        }
+        
+        result = meta_decode(data)
+        
+        assert isinstance(result, AttachmentMetadata)
+        assert result.filename == "file_with_description_only.md"
+        assert result.sha256_hash == "xyz789uvw456abc123def4567890abc123def4567890abc123def4567890abc"
+        assert result.mimetype is None
+        assert result.description == "File with description but no mimetype"
+
+    def test_round_trip_with_none_mimetype(self):
+        """Test round-trip encoding and decoding with mimetype=None."""
+        original = AttachmentMetadata(
+            filename="unknown_type.xyz",
+            sha256_hash="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            mimetype=None,
+            description="File with unknown type"
+        )
+        
+        # Encode then decode
+        encoded = meta_encode(original)
+        decoded = meta_decode(encoded)
+        
+        # Verify round trip preserves all data
+        assert decoded.filename == original.filename
+        assert decoded.sha256_hash == original.sha256_hash
+        assert decoded.mimetype is None  # Should remain None
+        assert decoded.description == original.description
+        
+        # Verify encoded object doesn't include mimetype field
+        assert "mimetype" not in encoded
+        assert encoded["description"] == "File with unknown type"
+
+    def test_round_trip_with_none_mimetype_no_description(self):
+        """Test round-trip encoding and decoding with mimetype=None and no description."""
+        original = AttachmentMetadata(
+            filename="minimal_file.tmp",
+            sha256_hash="abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+            mimetype=None,
+            description=None
+        )
+        
+        # Encode then decode
+        encoded = meta_encode(original)
+        decoded = meta_decode(encoded)
+        
+        # Verify round trip preserves all data
+        assert decoded.filename == original.filename
+        assert decoded.sha256_hash == original.sha256_hash
+        assert decoded.mimetype is None
+        assert decoded.description is None
+        
+        # Verify encoded object only includes required fields
+        assert encoded == {
+            "filename": "minimal_file.tmp",
+            "sha256_hash": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+        }
+        assert "mimetype" not in encoded
+        assert "description" not in encoded

--- a/tests/test_exchange_model_package_v1_metadata.py
+++ b/tests/test_exchange_model_package_v1_metadata.py
@@ -12,6 +12,7 @@ from overity.model.ml_model.metadata import (
     MLModelAuthor,
     MLModelMaintainer,
 )
+from overity.model.ml_model.attachment import AttachmentMetadata
 
 
 class TestModelPackageV1Metadata:
@@ -166,5 +167,390 @@ class TestModelPackageV1Metadata:
             for i in range(len(result.maintainers)):
                 assert result.maintainers[i].name == original.maintainers[i].name
                 assert result.maintainers[i].email == original.maintainers[i].email
+        finally:
+            temp_path.unlink()
+
+    def test_model_metadata_with_attachments(self):
+        """Test parsing model metadata with attachments."""
+        data = {
+            "name": "Model with Attachments",
+            "version": "1.0.0",
+            "authors": [{"name": "John Doe", "email": "john@example.com"}],
+            "maintainers": [
+                {"name": "Maintainer One", "email": "maintainer1@example.com"}
+            ],
+            "target": "test-target",
+            "format": "onnx",
+            "model_file": "model.onnx",
+            "attachments": [
+                {
+                    "filename": "README.md",
+                    "sha256_hash": "abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
+                    "mimetype": "text/markdown",
+                    "description": "Model documentation"
+                },
+                {
+                    "filename": "license.txt",
+                    "sha256_hash": "def456abc1237890def456abc1237890def456abc1237890def456abc1237890",
+                    "mimetype": "text/plain"
+                }
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+
+            try:
+                result = from_file(Path(f.name))
+                assert isinstance(result, MLModelMetadata)
+                assert result.name == "Model with Attachments"
+                assert result.version == "1.0.0"
+                assert len(result.attachments) == 2
+
+                # Check first attachment
+                assert isinstance(result.attachments[0], AttachmentMetadata)
+                assert result.attachments[0].filename == "README.md"
+                assert result.attachments[0].sha256_hash == "abc123def4567890abc123def4567890abc123def4567890abc123def4567890"
+                assert result.attachments[0].mimetype == "text/markdown"
+                assert result.attachments[0].description == "Model documentation"
+
+                # Check second attachment (without description)
+                assert isinstance(result.attachments[1], AttachmentMetadata)
+                assert result.attachments[1].filename == "license.txt"
+                assert result.attachments[1].sha256_hash == "def456abc1237890def456abc1237890def456abc1237890def456abc1237890"
+                assert result.attachments[1].mimetype == "text/plain"
+                assert result.attachments[1].description is None
+
+            finally:
+                Path(f.name).unlink()
+
+    def test_model_metadata_with_empty_attachments(self):
+        """Test parsing model metadata with empty attachments list."""
+        data = {
+            "name": "Model with Empty Attachments",
+            "version": "1.0.0",
+            "authors": [{"name": "John Doe", "email": "john@example.com"}],
+            "maintainers": [
+                {"name": "Maintainer One", "email": "maintainer1@example.com"}
+            ],
+            "target": "test-target",
+            "format": "onnx",
+            "model_file": "model.onnx",
+            "attachments": []
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+
+            try:
+                result = from_file(Path(f.name))
+                assert isinstance(result, MLModelMetadata)
+                assert result.name == "Model with Empty Attachments"
+                assert len(result.attachments) == 0
+
+            finally:
+                Path(f.name).unlink()
+
+    def test_model_metadata_without_attachments_field(self):
+        """Test parsing model metadata without attachments field (should default to empty)."""
+        data = {
+            "name": "Model without Attachments",
+            "version": "1.0.0",
+            "authors": [{"name": "John Doe", "email": "john@example.com"}],
+            "maintainers": [
+                {"name": "Maintainer One", "email": "maintainer1@example.com"}
+            ],
+            "target": "test-target",
+            "format": "onnx",
+            "model_file": "model.onnx"
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+
+            try:
+                result = from_file(Path(f.name))
+                assert isinstance(result, MLModelMetadata)
+                assert result.name == "Model without Attachments"
+                assert len(result.attachments) == 0
+
+            finally:
+                Path(f.name).unlink()
+
+    def test_round_trip_model_metadata_with_attachments(self):
+        """Test that encoding and decoding a MLModelMetadata with attachments works correctly."""
+        original = MLModelMetadata(
+            name="Round Trip Model with Attachments",
+            version="2.0.0",
+            authors=[
+                MLModelAuthor(
+                    name="John Doe", email="john@example.com", contribution=None
+                )
+            ],
+            maintainers=[
+                MLModelMaintainer(
+                    name="Maintainer One", email="maintainer1@example.com"
+                )
+            ],
+            target="round-trip-target",
+            exchange_format="onnx",
+            model_file="model.onnx",
+            attachments=[
+                AttachmentMetadata(
+                    filename="README.md",
+                    sha256_hash="abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
+                    mimetype="text/markdown",
+                    description="Model documentation"
+                ),
+                AttachmentMetadata(
+                    filename="license.txt",
+                    sha256_hash="def456abc1237890def456abc1237890def456abc1237890def456abc1237890",
+                    mimetype="text/plain"
+                )
+            ]
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            temp_path = Path(f.name)
+
+        try:
+            # Encode to file
+            to_file(original, temp_path)
+
+            # Decode from file
+            result = from_file(temp_path)
+
+            # Assertions
+            assert result.name == original.name
+            assert result.version == original.version
+            assert result.target == original.target
+            assert result.exchange_format == original.exchange_format
+            assert result.model_file == original.model_file
+
+            # Check attachments
+            assert len(result.attachments) == len(original.attachments)
+            for i in range(len(result.attachments)):
+                assert isinstance(result.attachments[i], AttachmentMetadata)
+                assert result.attachments[i].filename == original.attachments[i].filename
+                assert result.attachments[i].sha256_hash == original.attachments[i].sha256_hash
+                assert result.attachments[i].mimetype == original.attachments[i].mimetype
+                assert result.attachments[i].description == original.attachments[i].description
+
+            assert len(result.authors) == len(original.authors)
+            for i in range(len(result.authors)):
+                assert result.authors[i].name == original.authors[i].name
+                assert result.authors[i].email == original.authors[i].email
+
+            assert len(result.maintainers) == len(original.maintainers)
+            for i in range(len(result.maintainers)):
+                assert result.maintainers[i].name == original.maintainers[i].name
+                assert result.maintainers[i].email == original.maintainers[i].email
+
+        finally:
+            temp_path.unlink()
+
+    def test_model_metadata_encoding_with_attachments(self):
+        """Test encoding model metadata with attachments to JSON."""
+        original = MLModelMetadata(
+            name="Encoding Test Model",
+            version="1.0.0",
+            authors=[
+                MLModelAuthor(name="John Doe", email="john@example.com")
+            ],
+            maintainers=[
+                MLModelMaintainer(name="Maintainer One", email="maintainer1@example.com")
+            ],
+            target="encoding-test",
+            exchange_format="onnx",
+            model_file="model.onnx",
+            attachments=[
+                AttachmentMetadata(
+                    filename="config.yaml",
+                    sha256_hash="xyz789uvw456abc123def4567890abc123def4567890abc123def4567890abc",
+                    mimetype="application/x-yaml",
+                    description="Model configuration"
+                )
+            ]
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            temp_path = Path(f.name)
+
+        try:
+            # Encode to file
+            to_file(original, temp_path)
+
+            # Read the JSON content
+            with open(temp_path) as f:
+                data = json.load(f)
+
+            # Verify the structure
+            assert data["name"] == "Encoding Test Model"
+            assert data["version"] == "1.0.0"
+            assert data["target"] == "encoding-test"
+            assert data["format"] == "onnx"
+            assert data["model_file"] == "model.onnx"
+
+            # Verify attachments
+            assert "attachments" in data
+            assert len(data["attachments"]) == 1
+            attachment = data["attachments"][0]
+            assert attachment["filename"] == "config.yaml"
+            assert attachment["sha256_hash"] == "xyz789uvw456abc123def4567890abc123def4567890abc123def4567890abc"
+            assert attachment["mimetype"] == "application/x-yaml"
+            assert attachment["description"] == "Model configuration"
+
+        finally:
+            temp_path.unlink()
+
+    def test_model_metadata_with_invalid_attachment_data(self):
+        """Test parsing model metadata with invalid attachment data."""
+        data = {
+            "name": "Model with Invalid Attachments",
+            "version": "1.0.0",
+            "authors": [{"name": "John Doe", "email": "john@example.com"}],
+            "maintainers": [
+                {"name": "Maintainer One", "email": "maintainer1@example.com"}
+            ],
+            "target": "test-target",
+            "format": "onnx",
+            "model_file": "model.onnx",
+            "attachments": [
+                {
+                    # Missing required fields
+                    "filename": "invalid.txt"
+                }
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+
+            try:
+                # Should raise KeyError due to missing required fields
+                with pytest.raises(KeyError):
+                    from_file(Path(f.name))
+
+            finally:
+                Path(f.name).unlink()
+
+    def test_model_metadata_with_attachments_having_none_mimetype(self):
+        """Test parsing model metadata with attachments that have mimetype=None."""
+        data = {
+            "name": "Model with None Mimetype Attachments",
+            "version": "1.0.0",
+            "authors": [{"name": "John Doe", "email": "john@example.com"}],
+            "maintainers": [
+                {"name": "Maintainer One", "email": "maintainer1@example.com"}
+            ],
+            "target": "test-target",
+            "format": "onnx",
+            "model_file": "model.onnx",
+            "attachments": [
+                {
+                    "filename": "unknown_type.xyz",
+                    "sha256_hash": "abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
+                    "description": "File with unknown mimetype"
+                },
+                {
+                    "filename": "another_unknown.tmp",
+                    "sha256_hash": "def456abc1237890def456abc1237890def456abc1237890def456abc1237890"
+                }
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+
+            try:
+                result = from_file(Path(f.name))
+                assert isinstance(result, MLModelMetadata)
+                assert result.name == "Model with None Mimetype Attachments"
+                assert len(result.attachments) == 2
+
+                # Check first attachment (with description, no mimetype)
+                assert isinstance(result.attachments[0], AttachmentMetadata)
+                assert result.attachments[0].filename == "unknown_type.xyz"
+                assert result.attachments[0].sha256_hash == "abc123def4567890abc123def4567890abc123def4567890abc123def4567890"
+                assert result.attachments[0].mimetype is None
+                assert result.attachments[0].description == "File with unknown mimetype"
+
+                # Check second attachment (no mimetype, no description)
+                assert isinstance(result.attachments[1], AttachmentMetadata)
+                assert result.attachments[1].filename == "another_unknown.tmp"
+                assert result.attachments[1].sha256_hash == "def456abc1237890def456abc1237890def456abc1237890def456abc1237890"
+                assert result.attachments[1].mimetype is None
+                assert result.attachments[1].description is None
+
+            finally:
+                Path(f.name).unlink()
+
+    def test_round_trip_model_metadata_with_none_mimetype_attachments(self):
+        """Test round-trip encoding/decoding of model metadata with attachments having mimetype=None."""
+        original = MLModelMetadata(
+            name="Round Trip Model with None Mimetype Attachments",
+            version="1.0.0",
+            authors=[
+                MLModelAuthor(name="John Doe", email="john@example.com")
+            ],
+            maintainers=[
+                MLModelMaintainer(name="Maintainer One", email="maintainer1@example.com")
+            ],
+            target="round-trip-target",
+            exchange_format="onnx",
+            model_file="model.onnx",
+            attachments=[
+                AttachmentMetadata(
+                    filename="unknown_type.xyz",
+                    sha256_hash="abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
+                    mimetype=None,
+                    description="File with unknown mimetype"
+                ),
+                AttachmentMetadata(
+                    filename="minimal_file.tmp",
+                    sha256_hash="def456abc1237890def456abc1237890def456abc1237890def456abc1237890",
+                    mimetype=None
+                )
+            ]
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            temp_path = Path(f.name)
+
+        try:
+            # Encode to file
+            to_file(original, temp_path)
+
+            # Read the JSON content to verify encoding
+            with open(temp_path) as f:
+                json_data = json.load(f)
+
+            # Verify that attachments don't have mimetype field in JSON when it's None
+            assert "attachments" in json_data
+            assert len(json_data["attachments"]) == 2
+            assert "mimetype" not in json_data["attachments"][0]
+            assert "mimetype" not in json_data["attachments"][1]
+            assert json_data["attachments"][0]["description"] == "File with unknown mimetype"
+            assert "description" not in json_data["attachments"][1]
+
+            # Decode from file
+            result = from_file(temp_path)
+
+            # Verify round-trip integrity
+            assert result.name == original.name
+            assert len(result.attachments) == len(original.attachments)
+
+            for i in range(len(result.attachments)):
+                assert isinstance(result.attachments[i], AttachmentMetadata)
+                assert result.attachments[i].filename == original.attachments[i].filename
+                assert result.attachments[i].sha256_hash == original.attachments[i].sha256_hash
+                assert result.attachments[i].mimetype is None  # Should remain None
+                assert result.attachments[i].description == original.attachments[i].description
+
         finally:
             temp_path.unlink()

--- a/tests/test_exchange_model_package_v1_package.py
+++ b/tests/test_exchange_model_package_v1_package.py
@@ -9,11 +9,11 @@ import json
 import os
 from pathlib import Path
 from overity.exchange.model_package_v1.package import (
-    package_sha256,
     package_archive_create,
     metadata_load,
     model_load,
 )
+from overity.exchange import integrity
 from overity.model.ml_model.metadata import (
     MLModelMetadata,
     MLModelAuthor,
@@ -24,7 +24,7 @@ from overity.errors import MalformedModelPackage
 
 
 class TestModelPackageV1Package:
-    def test_package_sha256(self):
+    def test_file_sha256(self):
         """Test computing SHA256 hash of a file."""
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(b"test content")
@@ -32,7 +32,7 @@ class TestModelPackageV1Package:
             path = Path(f.name)
 
         try:
-            result = package_sha256(path).hexdigest()
+            result = integrity.file_sha256(path).hexdigest()
             # Known SHA256 hash of "test content"
             assert (
                 result

--- a/tests/test_exchange_model_package_v1_package.py
+++ b/tests/test_exchange_model_package_v1_package.py
@@ -20,6 +20,7 @@ from overity.model.ml_model.metadata import (
     MLModelMaintainer,
 )
 from overity.model.ml_model.package import MLModelPackage
+from overity.model.ml_model.attachment import AttachmentMetadata, ExtractedAttachment
 from overity.errors import MalformedModelPackage
 
 
@@ -308,11 +309,13 @@ class TestModelPackageV1Package:
                         package_archive_create(package_info, output_path)
 
                         # Load model
-                        loaded_metadata = model_load(output_path, target_path)
+                        loaded_metadata, loaded_attachments = model_load(output_path, target_path)
 
                         # Verify metadata
                         assert isinstance(loaded_metadata, MLModelMetadata)
                         assert loaded_metadata.name == "Test Model"
+                        assert isinstance(loaded_attachments, dict)
+                        assert len(loaded_attachments) == 0  # No attachments in this test
 
                         # Verify model file was extracted
                         extracted_file = target_path / "model.onnx"
@@ -406,3 +409,426 @@ class TestModelPackageV1Package:
             finally:
                 archive_path.unlink()
                 meta_path.unlink()
+
+    def test_model_load_with_attachments(self):
+        """Test loading a model package with attachments."""
+        # Create temporary model file
+        with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+            f.write(b"fake model content")
+            model_file_path = Path(f.name)
+
+        # Create temporary attachment files
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write("This is attachment content")
+            attachment1_path = Path(f.name)
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write("# Documentation\nThis is documentation content")
+            attachment2_path = Path(f.name)
+
+        try:
+            # Create metadata with attachments (use actual file names)
+            metadata = MLModelMetadata(
+                name="Model with Attachments",
+                version="1.0.0",
+                authors=[MLModelAuthor(name="John Doe", email="john@example.com")],
+                maintainers=[
+                    MLModelMaintainer(name="Jane Smith", email="jane@example.com")
+                ],
+                target="test-target",
+                exchange_format="onnx",
+                model_file="model.onnx",
+                attachments=[
+                    AttachmentMetadata(
+                        filename=attachment1_path.name,  # Use actual file name
+                        sha256_hash="2dbb0f5c8c7d5e3f7a9b8c7d5e3f7a9b8c7d5e3f7a9b8c7d5e3f7a9b8c7d5e3f7",
+                        mimetype="text/plain",
+                        description="README file"
+                    ),
+                    AttachmentMetadata(
+                        filename=attachment2_path.name,  # Use actual file name
+                        sha256_hash="3eaa1f6d9d8e6f4b9b7a9d8e6f4b9b7a9d8e6f4b9b7a9d8e6f4b9b7a9d8e6f4b",
+                        mimetype="text/markdown"
+                    )
+                ]
+            )
+
+            # Create package info
+            package_info = MLModelPackage(
+                metadata=metadata,
+                model_file_path=model_file_path,
+                attachments_files=[attachment1_path, attachment2_path]
+            )
+
+            # Create output path
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+                output_path = Path(f.name)
+
+            # Create extraction target directory
+            with tempfile.TemporaryDirectory() as target_dir:
+                target_path = Path(target_dir)
+
+                try:
+                    # Create package archive
+                    package_archive_create(package_info, output_path)
+
+                    # Load model with attachments
+                    loaded_metadata, loaded_attachments = model_load(output_path, target_path)
+
+                    # Verify metadata
+                    assert isinstance(loaded_metadata, MLModelMetadata)
+                    assert loaded_metadata.name == "Model with Attachments"
+                    assert len(loaded_metadata.attachments) == 2
+
+                    # Verify attachments dictionary
+                    assert isinstance(loaded_attachments, dict)
+                    assert len(loaded_attachments) == 2
+                    
+                    # Get attachment keys (temporary file names)
+                    att_keys = list(loaded_attachments.keys())
+                    assert len(att_keys) == 2
+                    
+                    # Verify first attachment (should be the .txt file)
+                    txt_key = [k for k in att_keys if k.endswith('.txt')][0]
+                    readme_att = loaded_attachments[txt_key]
+                    assert isinstance(readme_att, ExtractedAttachment)
+                    assert readme_att.meta.filename == txt_key  # Should match the key
+                    assert readme_att.meta.mimetype == "text/plain"
+                    assert readme_att.meta.description == "README file"
+                    assert readme_att.path.exists()
+                    assert readme_att.path.read_text() == "This is attachment content"
+
+                    # Verify second attachment (should be the .md file)
+                    md_key = [k for k in att_keys if k.endswith('.md')][0]
+                    docs_att = loaded_attachments[md_key]
+                    assert isinstance(docs_att, ExtractedAttachment)
+                    assert docs_att.meta.filename == md_key  # Should match the key
+                    assert docs_att.meta.mimetype == "text/markdown"
+                    assert docs_att.meta.description is None
+                    assert docs_att.path.exists()
+                    assert docs_att.path.read_text() == "# Documentation\nThis is documentation content"
+
+                    # Verify attachments folder was created
+                    attachments_folder = target_path / "attachments"
+                    assert attachments_folder.exists()
+                    assert attachments_folder.is_dir()
+
+                    # Verify model file was extracted
+                    extracted_model = target_path / "model.onnx"
+                    assert extracted_model.exists()
+                    assert extracted_model.read_bytes() == b"fake model content"
+
+                finally:
+                    output_path.unlink()
+        finally:
+            model_file_path.unlink()
+            attachment1_path.unlink()
+            attachment2_path.unlink()
+
+    def test_model_load_with_empty_attachments(self):
+        """Test loading a model package with no attachments."""
+        # Create temporary model file
+        with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+            f.write(b"fake model content")
+            model_file_path = Path(f.name)
+
+        try:
+            # Create metadata without attachments
+            metadata = MLModelMetadata(
+                name="Model without Attachments",
+                version="1.0.0",
+                authors=[MLModelAuthor(name="John Doe", email="john@example.com")],
+                maintainers=[
+                    MLModelMaintainer(name="Jane Smith", email="jane@example.com")
+                ],
+                target="test-target",
+                exchange_format="onnx",
+                model_file="model.onnx",
+                attachments=[]  # Empty attachments list
+            )
+
+            # Create package info
+            package_info = MLModelPackage(
+                metadata=metadata,
+                model_file_path=model_file_path,
+                attachments_files=[]  # No attachment files
+            )
+
+            # Create output path
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+                output_path = Path(f.name)
+
+            # Create extraction target directory
+            with tempfile.TemporaryDirectory() as target_dir:
+                target_path = Path(target_dir)
+
+                try:
+                    # Create package archive
+                    package_archive_create(package_info, output_path)
+
+                    # Load model
+                    loaded_metadata, loaded_attachments = model_load(output_path, target_path)
+
+                    # Verify metadata
+                    assert isinstance(loaded_metadata, MLModelMetadata)
+                    assert loaded_metadata.name == "Model without Attachments"
+                    assert len(loaded_metadata.attachments) == 0
+
+                    # Verify empty attachments dictionary
+                    assert isinstance(loaded_attachments, dict)
+                    assert len(loaded_attachments) == 0
+
+                    # Verify attachments folder was NOT created (no attachments)
+                    attachments_folder = target_path / "attachments"
+                    assert not attachments_folder.exists()
+
+                    # Verify model file was extracted
+                    extracted_model = target_path / "model.onnx"
+                    assert extracted_model.exists()
+                    assert extracted_model.read_bytes() == b"fake model content"
+
+                finally:
+                    output_path.unlink()
+        finally:
+            model_file_path.unlink()
+
+    def test_model_load_with_attachment_integrity_check(self):
+        """Test that attachment integrity is verified during model loading."""
+        # Create temporary model file
+        with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+            f.write(b"fake model content")
+            model_file_path = Path(f.name)
+
+        # Create temporary attachment file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            f.write("This is attachment content")
+            attachment_path = Path(f.name)
+
+        try:
+            # Create metadata with WRONG hash for attachment (use actual file name)
+            metadata = MLModelMetadata(
+                name="Model with Bad Attachment Hash",
+                version="1.0.0",
+                authors=[MLModelAuthor(name="John Doe", email="john@example.com")],
+                maintainers=[
+                    MLModelMaintainer(name="Jane Smith", email="jane@example.com")
+                ],
+                target="test-target",
+                exchange_format="onnx",
+                model_file="model.onnx",
+                attachments=[
+                    AttachmentMetadata(
+                        filename=attachment_path.name,  # Use actual file name
+                        sha256_hash="wrong_hash_value_123456789012345678901234567890123456789012345678901234567890",
+                        mimetype="text/plain"
+                    )
+                ]
+            )
+
+            # Create package info
+            package_info = MLModelPackage(
+                metadata=metadata,
+                model_file_path=model_file_path,
+                attachments_files=[attachment_path]
+            )
+
+            # Create output path
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+                output_path = Path(f.name)
+
+            # Create extraction target directory
+            with tempfile.TemporaryDirectory() as target_dir:
+                target_path = Path(target_dir)
+
+                try:
+                    # Create package archive
+                    package_archive_create(package_info, output_path)
+
+                    # Load model - should work despite wrong hash in metadata
+                    # (integrity check happens separately, not during load)
+                    loaded_metadata, loaded_attachments = model_load(output_path, target_path)
+
+                    # Verify metadata was loaded correctly
+                    assert isinstance(loaded_metadata, MLModelMetadata)
+                    assert loaded_metadata.name == "Model with Bad Attachment Hash"
+                    assert len(loaded_attachments) == 1
+
+                    # The attachment should be extracted even with wrong hash
+                    att_key = list(loaded_attachments.keys())[0]  # Get the actual key
+                    readme_att = loaded_attachments[att_key]
+                    assert readme_att.path.exists()
+                    assert readme_att.path.read_text() == "This is attachment content"
+
+                    # But the hash in metadata is wrong (this would be caught by separate integrity check)
+                    assert readme_att.meta.sha256_hash == "wrong_hash_value_123456789012345678901234567890123456789012345678901234567890"
+
+                finally:
+                    output_path.unlink()
+        finally:
+            model_file_path.unlink()
+            attachment_path.unlink()
+
+    def test_model_load_with_missing_attachment_file(self):
+        """Test loading a model package when an attachment file is missing from archive."""
+        # Create temporary model file
+        with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+            f.write(b"fake model content")
+            model_file_path = Path(f.name)
+
+        try:
+            # Create metadata with attachment that won't be in archive
+            metadata = MLModelMetadata(
+                name="Model with Missing Attachment",
+                version="1.0.0",
+                authors=[MLModelAuthor(name="John Doe", email="john@example.com")],
+                maintainers=[
+                    MLModelMaintainer(name="Jane Smith", email="jane@example.com")
+                ],
+                target="test-target",
+                exchange_format="onnx",
+                model_file="model.onnx",
+                attachments=[
+                    AttachmentMetadata(
+                        filename="missing.txt",
+                        sha256_hash="abc123def4567890abc123def4567890abc123def4567890abc123def4567890",
+                        mimetype="text/plain"
+                    )
+                ]
+            )
+
+            # Create package info WITHOUT the attachment file
+            package_info = MLModelPackage(
+                metadata=metadata,
+                model_file_path=model_file_path,
+                attachments_files=[]  # Don't include the attachment file
+            )
+
+            # Create output path
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+                output_path = Path(f.name)
+
+            # Create extraction target directory
+            with tempfile.TemporaryDirectory() as target_dir:
+                target_path = Path(target_dir)
+
+                try:
+                    # Create package archive (without attachment)
+                    package_archive_create(package_info, output_path)
+
+                    # Try to load model - should fail because attachment is missing
+                    with pytest.raises(MalformedModelPackage) as exc_info:
+                        model_load(output_path, target_path)
+
+                    # Verify error message
+                    assert "missing.txt" in str(exc_info.value)
+                    assert "not found in archive" in str(exc_info.value)
+
+                finally:
+                    output_path.unlink()
+        finally:
+            model_file_path.unlink()
+
+    def test_round_trip_model_package_with_attachments(self):
+        """Test creating a package with attachments and then loading it back."""
+        # Create temporary model file
+        with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as f:
+            f.write(b"model content for round trip")
+            model_file_path = Path(f.name)
+
+        # Create temporary attachment files
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump({"config": "value", "version": 1}, f)
+            config_path = Path(f.name)
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write("# API Documentation\n\nThis is the API documentation.")
+            docs_path = Path(f.name)
+
+        try:
+            # Create metadata with attachments (use actual file names)
+            original_metadata = MLModelMetadata(
+                name="Round Trip Model with Attachments",
+                version="2.0.0",
+                authors=[MLModelAuthor(name="Test Author", email="test@example.com")],
+                maintainers=[MLModelMaintainer(name="Test Maintainer", email="maintainer@example.com")],
+                target="round-trip-target",
+                exchange_format="onnx",
+                model_file="model.onnx",
+                attachments=[
+                    AttachmentMetadata(
+                        filename=config_path.name,  # Use actual file name
+                        sha256_hash="dummy_hash_for_config",
+                        mimetype="application/json",
+                        description="Configuration file"
+                    ),
+                    AttachmentMetadata(
+                        filename=docs_path.name,   # Use actual file name
+                        sha256_hash="dummy_hash_for_docs",
+                        mimetype="text/markdown",
+                        description="Documentation"
+                    )
+                ]
+            )
+
+            # Create package info
+            original_package = MLModelPackage(
+                metadata=original_metadata,
+                model_file_path=model_file_path,
+                attachments_files=[config_path, docs_path]
+            )
+
+            # Create output path
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+                output_path = Path(f.name)
+
+            # Create extraction target directory
+            with tempfile.TemporaryDirectory() as target_dir:
+                target_path = Path(target_dir)
+
+                try:
+                    # Create package archive
+                    package_archive_create(original_package, output_path)
+
+                    # Load model with attachments
+                    loaded_metadata, loaded_attachments = model_load(output_path, target_path)
+
+                    # Verify metadata round-trip
+                    assert isinstance(loaded_metadata, MLModelMetadata)
+                    assert loaded_metadata.name == original_metadata.name
+                    assert loaded_metadata.version == original_metadata.version
+                    assert loaded_metadata.target == original_metadata.target
+                    assert len(loaded_metadata.attachments) == len(original_metadata.attachments)
+
+                    # Verify attachments round-trip
+                    assert isinstance(loaded_attachments, dict)
+                    assert len(loaded_attachments) == len(original_metadata.attachments)
+
+                    for i, (filename, extracted_att) in enumerate(loaded_attachments.items()):
+                        assert isinstance(extracted_att, ExtractedAttachment)
+                        assert extracted_att.meta.filename == original_metadata.attachments[i].filename
+                        assert extracted_att.meta.mimetype == original_metadata.attachments[i].mimetype
+                        assert extracted_att.meta.description == original_metadata.attachments[i].description
+                        
+                        # Verify extracted file exists and has correct content
+                        assert extracted_att.path.exists()
+                        assert extracted_att.path.is_file()
+
+                    # Verify specific file contents
+                    config_key = [k for k in loaded_attachments.keys() if k.endswith('.json')][0]
+                    docs_key = [k for k in loaded_attachments.keys() if k.endswith('.md')][0]
+                    assert loaded_attachments[config_key].path.read_text() == '{"config": "value", "version": 1}'
+                    assert "# API Documentation" in loaded_attachments[docs_key].path.read_text()
+
+                    # Verify attachments folder structure
+                    attachments_folder = target_path / "attachments"
+                    assert attachments_folder.exists()
+                    assert attachments_folder.is_dir()
+                    assert (attachments_folder / config_key).exists()
+                    assert (attachments_folder / docs_key).exists()
+
+                finally:
+                    output_path.unlink()
+        finally:
+            model_file_path.unlink()
+            config_path.unlink()
+            docs_path.unlink()


### PR DESCRIPTION
Closes #42

This PR introduces model attachment functionality for ML model packages.

**Breaking Changes:**
- `StorageBackend.model_load()` returns `(metadata, sha256_hash, attachments_dict)` instead of `(metadata, sha256_hash)`

## Changes

### Added
- `src/overity/exchange/model_package_v1/attachment.py` - Attachment encoder/decoder and utilities
- `src/overity/exchange/integrity.py` - File integrity utilities with SHA256 hashing
- `src/overity/model/ml_model/attachment.py` - Attachment data models (AttachmentMetadata, ExtractedAttachment)
- `tests/test_exchange_model_package_v1_attachment.py` - 28 attachment test cases
- `tests/test_exchange_integrity.py` - 15 integrity utility test cases
- `AttachmentIntegrityError` exception type

### Modified
- `src/overity/exchange/model_package_v1/metadata.py` - Added attachment support to metadata encoding/decoding
- `src/overity/exchange/model_package_v1/package.py` - Added attachment extraction and packaging
- `src/overity/model/ml_model/metadata.py` - Added attachments field to MLModelMetadata
- `src/overity/model/ml_model/package.py` - Added attachments_files field to MLModelPackage
- `src/overity/storage/local/__init__.py` - Implemented attachment handling in local storage
- `src/overity/exchange/dataset_package/package.py` - Refactored to use integrity.file_sha256
- `src/overity/exchange/inference_agent_package/package.py` - Refactored to use integrity.file_sha256
- `tests/test_exchange_model_package_v1_package.py` - Updated for new API and added attachment extraction tests
- `tests/test_exchange_model_package_v1_metadata.py` - Added attachment integration tests

### Functionality
- Attach files to model packages with metadata tracking (filename, SHA256 hash, MIME type, description)
- Extract attachments from model packages to `attachments/` directory
- MIME type detection using Python's mimetypes module
- SHA256 integrity verification for attachments
- Attachments stored in `attachments/` subdirectory within tar archives
- Optional mimetype and description fields (excluded from JSON when None)

### API Changes
```python
# Old
metadata, hash_obj = storage.model_load("model-name", target_path)

# New
metadata, hash_obj, attachments = storage.model_load("model-name", target_path)
# attachments is dict[str, ExtractedAttachment]
```

### Usage

#### Save model attachments

```python
with vapi.model_package("my_model", exchange_format="onnx") as vpkg:
    vpkg.maintainer_add("John Doe", "john.doe@mail.com")

    with open(vkpg.model_file, "wb") as fhandle:
        fhandle.write(onnx.SerializeToString())

    att_path = vpkg.attachment_add("label_classes.npy", "Label encoder classes")
    np.save(att_path, label_encoder.classes_)
```

#### Use model attachments

```python
model_file, model_data, model_attachments = vapi.model_use(model_name)

att_label_classes = model_attachments["label_classes.npy"]
label_encoder = LabelEncoder()
label_encoder.classes_ = np.load(att_label_classes.path, allow_pickle = True)
```


### Test Coverage
- 28 attachment-specific tests
- 15 integrity utility tests
- Package creation/extraction integration tests
- Error handling for missing files and integrity failures
