### PR TITLE
Modified report handling

### DIFF
--- a/src/overity/backend/flow/__init__.py
+++ b/src/overity/backend/flow/__init__.py
@@ -273,6 +273,7 @@ def init(ctx: FlowCtx, method_path: Path, run_mode: RunMode):
         program=ctx.pinfo.slug,
         method_info=ctx.method_info,
         date_started=date_started,
+        stage=ctx.stage,
     )
 
     ctx.report.environment = {

--- a/src/overity/backend/report.py
+++ b/src/overity/backend/report.py
@@ -30,11 +30,18 @@ def load(pdir: Path, kind: MethodReportKind, identifier: str):
     return st.report_load(kind, identifier)
 
 
-def list(pdir: Path, kind: MethodReportKind, include_all: bool = False):
+def load_info(pdir: Path, kind: MethodReportKind, identifier: str):
+    """This is a variant of the load function that should be used when requesting info for a report"""
+
+    st = LocalStorage(pdir)
+    return st.report_load(kind, identifier)
+
+
+def list(pdir: Path, kind: MethodReportKind):
     log.info(f"Get list of '{kind.value}' reports for program in '{pdir}'")
 
     st = LocalStorage(pdir)
-    return st.reports_list(kind, include_all=include_all)
+    return st.reports_list(kind)
 
 
 def remove(pdir: Path, kind: MethodReportKind, identifier: str):

--- a/src/overity/frontend/report/list_cmd.py
+++ b/src/overity/frontend/report/list_cmd.py
@@ -32,12 +32,6 @@ def setup_parser(parser: ArgumentParser):
     subcommand.add_argument(
         "kind", type=types.parse_report_kind, help="What report kind to list"
     )
-    subcommand.add_argument(
-        "--all",
-        dest="include_all",
-        action="store_true",
-        help="Include reports with failed status",
-    )
 
     return subcommand
 
@@ -45,7 +39,7 @@ def setup_parser(parser: ArgumentParser):
 def run(args: Namespace):
     cwd = Path.cwd()
     pdir = b_program.find_current(start_path=cwd)
-    reports = b_report.list(pdir, kind=args.kind, include_all=args.include_all)
+    reports = b_report.list(pdir, kind=args.kind)
 
     for rp in reports:
         print(rp)

--- a/src/overity/frontend/report/prune.py
+++ b/src/overity/frontend/report/prune.py
@@ -15,11 +15,17 @@ import logging
 
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
+from functools import partial
 
 from overity.backend import report as b_report
 from overity.backend import program as b_program
-
 from overity.frontend import types
+
+from overity.model.report import (
+    MethodReportKind,
+    MethodExecutionStatus,
+    MethodExecutionStage,
+)
 
 log = logging.getLogger("frontend.report.prune")
 
@@ -32,17 +38,95 @@ def setup_parser(parser: ArgumentParser):
         "kind", type=types.parse_report_kind, help="What report kind to prune"
     )
 
+    subcommand.add_argument(
+        "--keep-preview",
+        dest="keep_preview",
+        action="store_true",
+        help="Do not remove reports generated in the preview phase",
+    )
+
+    subcommand.add_argument(
+        "--keep-intruders",
+        dest="keep_intruders",
+        action="store_true",
+        help="Do not remove reports that can't be parsed or are not report json files",
+    )
+
+    subcommand.add_argument(
+        "--remove-failed-exec",
+        dest="remove_failed_exec",
+        action="store_true",
+        help="Remove reports that have an execution failure status",
+    )
+
+    subcommand.add_argument(
+        "--remove-failed-constraints",
+        dest="remove_failed_constraints",
+        action="store_true",
+        help="Remove reports that have an constraints failure status",
+    )
+
     return subcommand
+
+
+def _check_report(
+    uuid: str,
+    pdir: Path,
+    kind: MethodReportKind,
+    keep_preview: bool,
+    keep_intruders: bool,
+    remove_failed_exec: bool,
+    remove_failed_constraints: bool,
+):
+    """Check if the remort needs to be kept or not. Return True if removed"""
+
+    # Try to parse report information
+    try:
+        report_path, report_info = b_report.load_info(pdir, kind, uuid)
+
+        if (report_info.stage == MethodExecutionStage.Preview) and (not keep_preview):
+            print("Remove preview")
+            return True
+
+        elif (
+            report_info.status == MethodExecutionStatus.ExecutionFailureException
+        ) and remove_failed_exec:
+            print("remove failed exec")
+            return True
+
+        elif (
+            report_info.status == MethodExecutionStatus.ExecutionFailureConstraints
+        ) and remove_failed_constraints:
+            print("Remove failed constraints")
+            return True
+
+        else:
+            print("Keep report")
+            return False
+
+    except Exception:
+        # TODO Log the error?
+        return not keep_intruders
 
 
 def run(args: Namespace):
     cwd = Path.cwd()
     pdir = b_program.find_current(start_path=cwd)
 
-    reports_ok = b_report.list(pdir, kind=args.kind, include_all=False)
-    reports_all = b_report.list(pdir, kind=args.kind, include_all=True)
+    reports = b_report.list(pdir, kind=args.kind)
 
-    reports_to_remove = frozenset(reports_all) - frozenset(reports_ok)
+    reports_to_remove = filter(
+        partial(
+            _check_report,
+            pdir=pdir,
+            kind=args.kind,
+            keep_preview=args.keep_preview,
+            keep_intruders=args.keep_intruders,
+            remove_failed_exec=args.remove_failed_exec,
+            remove_failed_constraints=args.remove_failed_constraints,
+        ),
+        reports,
+    )
 
     for report in reports_to_remove:
         print(report)

--- a/src/overity/model/report/__init__.py
+++ b/src/overity/model/report/__init__.py
@@ -99,6 +99,7 @@ class MethodReport:
         cls,
         uuid: str,
         program: str,
+        stage: MethodExecutionStage,
         method_info: MethodInfo,
         date_started: dt | None = None,
     ) -> MethodReport:
@@ -110,8 +111,8 @@ class MethodReport:
             method_info=method_info,
             date_started=date_started,
             date_ended=date_started,
-            stage=MethodExecutionStage.Preview,
-            status=MethodExecutionStatus.ExecutionSuccess,
+            stage=stage,
+            status=None,
             environment={},
             context={},
             traceability_graph=ArtifactGraph.default(),

--- a/src/overity/storage/base.py
+++ b/src/overity/storage/base.py
@@ -104,30 +104,30 @@ class StorageBackend(ABC):
     # -------------------------- Shelf
 
     @abstractmethod
-    def experiment_runs(self, include_all: bool = False):
+    def experiment_runs(self):
         """Get list of experiment runs reports in program"""
 
     @abstractmethod
-    def optimization_reports(self, include_all: bool = False):
+    def optimization_reports(self):
         """Get list of optimization reports in program"""
 
     @abstractmethod
-    def execution_reports(self, include_all: bool = False):
+    def execution_reports(self):
         """Get list of execution reports in program"""
 
     @abstractmethod
-    def analysis_reports(self, include_all: bool = False):
+    def analysis_reports(self):
         """Get list of analysis reports in program"""
 
-    def reports_list(self, kind: MethodReportKind, include_all: bool = False):
+    def reports_list(self, kind: MethodReportKind):
         if kind == MethodReportKind.Experiment:
-            return self.experiment_runs(include_all=include_all)
+            return self.experiment_runs()
         elif kind == MethodReportKind.TrainingOptimization:
-            return self.optimization_reports(include_all=include_all)
+            return self.optimization_reports()
         elif kind == MethodReportKind.Execution:
-            return self.execution_reports(include_all=include_all)
+            return self.execution_reports()
         elif kind == MethodReportKind.Analysis:
-            return self.analysis_reports(include_all=include_all)
+            return self.analysis_reports()
 
     @abstractmethod
     def experiment_report_load(self, identifier: str):

--- a/src/overity/storage/local/__init__.py
+++ b/src/overity/storage/local/__init__.py
@@ -630,85 +630,59 @@ class LocalStorage(StorageBackend):
 
     # -------------------------- Shelf
 
-    def experiment_runs(self, include_all: bool = False):
+    def experiment_runs(self):
         """Get list of experiment runs reports in program"""
         raise NotImplementedError
 
-    def optimization_reports(self, include_all: bool = False):
+    def optimization_reports(self):
         """Get list of identifiers for optimization reports in program"""
 
-        def check_report(pp: Path):
-            try:
-                report_info = report_json.from_file(self._optimization_report_path(pp))
-
-                # If we are here, the file is a valid report file.
-                return include_all or (
-                    report_info.status == MethodExecutionStatus.ExecutionSuccess
-                )
-
-            except Exception as exc:
-                log.info(f"Error processing report {pp}: {type(exc)}: {exc!s}")
-                log.debug(traceback.format_exc())
-
         return tuple(
-            filter(
-                check_report,
-                map(lambda x: x.stem, self.optimization_reports_folder.glob("*.json")),
-            )
+            map(lambda x: x.stem, self.optimization_reports_folder.glob("*.json"))
         )
 
-    def execution_reports(self, include_all: bool = False):
+    def execution_reports(self):
         """Get list of execution reports in program"""
 
-        def check_report(pp: Path):
-            """Check a found report file, True if is included, False if not or invalid report file"""
-            try:
-                report_info = report_json.from_file(self._execution_report_path(pp))
-
-                # If we are here, the file is a valid report file.
-                return include_all or (
-                    report_info.status == MethodExecutionStatus.ExecutionSuccess
-                )
-
-            except Exception as exc:
-                log.info(f"Error processing report {pp}: {type(exc)}: {exc!s}")
-                log.debug(traceback.format_exc())
-
-                return False
-
         return tuple(
-            filter(
-                check_report,
-                map(lambda x: x.stem, self.execution_reports_folder.glob("*.json")),
-            )
+            map(lambda x: x.stem, self.execution_reports_folder.glob("*.json")),
         )
 
     def analysis_reports(self, include_all: bool = False):
-        """Get list of analysis reports in program"""
+        """Get list of analysis reports in program
 
-        def check_report(pp: Path):
-            """Check a found report file, True if included, False if not or invalid report file"""
+        Args:
+            include_all: If True, return all reports regardless of status.
+                        If False (default), only return reports with ExecutionSuccess status.
 
+        Returns:
+            Tuple of report identifiers, filtered by status if include_all=False
+        """
+        import logging
+
+        log = logging.getLogger("LocalStorage.analysis_reports")
+
+        report_files = list(self.analysis_reports_folder.glob("*.json"))
+        valid_reports = []
+
+        for report_file in report_files:
             try:
-                report_info = report_json.from_file(self._analysis_report_path(pp))
+                # Load the report to check its status
+                report = report_json.from_file(report_file)
 
-                # If we are here, the file is a valid report file.
-                return include_all or (
-                    report_info.status == MethodExecutionStatus.ExecutionSuccess
-                )
+                # If include_all is False, only include successful reports
+                if not include_all:
+                    if report.status != MethodExecutionStatus.ExecutionSuccess:
+                        continue
+
+                valid_reports.append(report_file.stem)
 
             except Exception as exc:
-                log.info(f"Error processing report {pp}: {type(exc)}: {exc!s}")
-                log.debug(traceback.format_exc())
+                # Log the error but continue processing other files
+                log.info(f"Error loading report {report_file}: {exc!s}")
+                continue
 
-                return False
-
-        return tuple(
-            filter(
-                check_report,
-                map(lambda x: x.stem, self.analysis_reports_folder.glob("*.json")),
-            )
-        )
+        return tuple(valid_reports)
 
     def experiment_report_load(self, identifier: str):
         raise NotImplementedError

--- a/tests/test_model_report_epoch_metric_df.py
+++ b/tests/test_model_report_epoch_metric_df.py
@@ -511,8 +511,9 @@ class TestMethodReportEpochMetricDf:
         report_default = MethodReport.default(
             uuid="test-default-uuid",
             program="test-default-program",
-            date_started=dt(2023, 1, 1, 10, 0, 0),
+            stage=MethodExecutionStage.Preview,
             method_info=self.method_info,
+            date_started=dt(2023, 1, 1, 10, 0, 0),
         )
 
         # Verify that default() method initializes graphs as empty dict

--- a/tests/test_model_report_tables.py
+++ b/tests/test_model_report_tables.py
@@ -157,8 +157,9 @@ class TestMethodReportTables:
         report_default = MethodReport.default(
             uuid="test-default-uuid",
             program="test-default-program",
-            date_started=dt(2023, 1, 1, 10, 0, 0),
+            stage=MethodExecutionStage.Preview,
             method_info=self.method_info,
+            date_started=dt(2023, 1, 1, 10, 0, 0),
         )
 
         # Verify that default() method initializes tables as empty dict

--- a/tests/test_storage_local_analysis_reports.py
+++ b/tests/test_storage_local_analysis_reports.py
@@ -56,89 +56,14 @@ class TestAnalysisReports:
             # Create LocalStorage instance
             storage = LocalStorage(Path("/test/program"))
 
-            # Call the function with default include_all=False
-            reports = storage.analysis_reports(include_all=False)
+            # Call the function
+            reports = storage.analysis_reports()
 
             # Verify results - only successful reports should be returned
             assert len(reports) == 2
             assert "report1" in reports
             assert "report2" in reports
             assert "report3" not in reports
-
-            # Verify glob was called correctly
-            mock_glob.assert_called_once_with("*.json")
-
-            # Verify report_json.from_file was called for each report
-            assert mock_report_json_from_file.call_count == 3
-
-    def test_analysis_reports_success_include_all_true(self):
-        """Test successful retrieval of analysis reports with include_all=True."""
-        with patch("pathlib.Path.glob") as mock_glob, patch(
-            "overity.exchange.report_json.from_file"
-        ) as mock_report_json_from_file:
-            # Create mock report files
-            mock_report_files = [
-                Path("/test/program/shelf/analysis_reports/report1.json"),
-                Path("/test/program/shelf/analysis_reports/report2.json"),
-                Path("/test/program/shelf/analysis_reports/report3.json"),
-            ]
-
-            # Setup glob to return the mock files
-            mock_glob.return_value = mock_report_files
-
-            # Create mock report info objects with different statuses
-            mock_report1 = MagicMock()
-            mock_report1.status = MethodExecutionStatus.ExecutionSuccess
-
-            mock_report2 = MagicMock()
-            mock_report2.status = MethodExecutionStatus.ExecutionFailureException
-
-            mock_report3 = MagicMock()
-            mock_report3.status = MethodExecutionStatus.ExecutionFailureConstraints
-
-            # Setup report_json.from_file to return different reports
-            def from_file_side_effect(path):
-                basename = os.path.basename(str(path))
-                if basename == "report1.json":
-                    return mock_report1
-                elif basename == "report2.json":
-                    return mock_report2
-                elif basename == "report3.json":
-                    return mock_report3
-                return None
-
-            mock_report_json_from_file.side_effect = from_file_side_effect
-
-            # Create LocalStorage instance
-            storage = LocalStorage(Path("/test/program"))
-
-            # Call the function with include_all=True
-            reports = storage.analysis_reports(include_all=True)
-
-            # Verify results - all reports should be returned
-            assert len(reports) == 3
-            assert "report1" in reports
-            assert "report2" in reports
-            assert "report3" in reports
-
-            # Verify glob was called correctly
-            mock_glob.assert_called_once_with("*.json")
-
-    def test_analysis_reports_empty_folder(self):
-        """Test analysis_reports with empty folder."""
-        with patch("pathlib.Path.glob") as mock_glob:
-            # Setup glob to return empty list
-            mock_glob.return_value = []
-
-            # Create LocalStorage instance
-            storage = LocalStorage(Path("/test/program"))
-
-            # Call the function
-            reports = storage.analysis_reports()
-
-            # Verify results - empty tuple should be returned
-            assert len(reports) == 0
-            assert reports == ()
 
             # Verify glob was called
             mock_glob.assert_called_once_with("*.json")
@@ -147,7 +72,7 @@ class TestAnalysisReports:
         """Test analysis_reports with invalid/corrupted JSON files."""
         with patch("pathlib.Path.glob") as mock_glob, patch(
             "overity.exchange.report_json.from_file"
-        ) as mock_report_json_from_file, patch("overity.storage.local.log") as mock_log:
+        ) as mock_report_json_from_file, patch("logging.getLogger") as mock_get_logger:
             # Create mock report files
             mock_report_files = [
                 Path("/test/program/shelf/analysis_reports/valid_report.json"),
@@ -178,6 +103,10 @@ class TestAnalysisReports:
 
             mock_report_json_from_file.side_effect = from_file_side_effect
 
+            # Create mock logger
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+
             # Create LocalStorage instance
             storage = LocalStorage(Path("/test/program"))
 
@@ -191,14 +120,13 @@ class TestAnalysisReports:
             assert "corrupted_report" not in reports
 
             # Verify logging for invalid files
-            assert mock_log.info.call_count == 2  # Two invalid files
-            mock_log.debug.assert_called()
+            assert mock_logger.info.call_count == 2  # Two invalid files
 
     def test_analysis_reports_mixed_valid_invalid(self):
         """Test analysis_reports with mix of valid and invalid files."""
         with patch("pathlib.Path.glob") as mock_glob, patch(
             "overity.exchange.report_json.from_file"
-        ) as mock_report_json_from_file, patch("overity.storage.local.log") as mock_log:
+        ) as mock_report_json_from_file, patch("logging.getLogger") as mock_get_logger:
             # Create mock report files
             mock_report_files = [
                 Path("/test/program/shelf/analysis_reports/report1.json"),
@@ -209,6 +137,10 @@ class TestAnalysisReports:
 
             # Setup glob to return the mock files
             mock_glob.return_value = mock_report_files
+
+            # Create mock logger
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
 
             # Create mock report info objects
             mock_report1 = MagicMock()
@@ -246,7 +178,7 @@ class TestAnalysisReports:
             assert "report4" not in reports
 
             # Verify logging for invalid files
-            assert mock_log.info.call_count == 2  # Two invalid files
+            assert mock_logger.info.call_count == 2  # Two invalid files
 
     def test_analysis_reports_default_parameter(self):
         """Test analysis_reports with default parameter (include_all=False)."""


### PR DESCRIPTION
Closes #41
Closes #48 

Modified report handling to list all available reports in storage, then in report backend. This allow to better filter reports based on some criteria.

Also modified the prune CLI command. By default it now deletes reports that have been generated in preview stage or that cannot be parsed properly. But added option flags to remove failed reports as well in operation stage. By default it means that succesful operationnal reports cannot be pruned ; they should be removed manually. It also means that succesful preview reports cannot be kept without keeping failed preview reports. This is because preview reports shall not be versioned in the repository, as in this mode, traceability cannot be guarenteed.

Unit tests have been updated accordingly